### PR TITLE
Fix data race when accessing results and capture groups

### DIFF
--- a/core/src/main/java/nl/inl/blacklab/search/TermFrequencyList.java
+++ b/core/src/main/java/nl/inl/blacklab/search/TermFrequencyList.java
@@ -204,7 +204,7 @@ public class TermFrequencyList extends Results<TermFrequency> {
 
     @Override
     public int numberOfResultObjects() {
-        return results.size();
+        return getResults().size();
     }
 
 }

--- a/core/src/main/java/nl/inl/blacklab/search/results/CapturedGroupsImpl.java
+++ b/core/src/main/java/nl/inl/blacklab/search/results/CapturedGroupsImpl.java
@@ -21,6 +21,11 @@ public class CapturedGroupsImpl implements CapturedGroups {
         capturedGroups = new HashMap<>();
     }
 
+    public CapturedGroupsImpl(CapturedGroupsImpl toCopy) {
+        this.capturedGroupNames = toCopy.capturedGroupNames;
+        this.capturedGroups = new HashMap<>(toCopy.capturedGroups);
+    }
+
     /**
      * Add groups for a hit
      * 

--- a/core/src/main/java/nl/inl/blacklab/search/results/DocGroups.java
+++ b/core/src/main/java/nl/inl/blacklab/search/results/DocGroups.java
@@ -67,7 +67,7 @@ public class DocGroups extends Results<DocGroup> implements ResultGroups<DocResu
                 largestGroupSize = group.size();
             totalResults += group.size();
             resultObjects += group.numberOfStoredHits() + 1;
-            results.add(group);
+            getResults().add(group);
             this.groups.put(group.identity(), group);
         }
     }
@@ -137,7 +137,7 @@ public class DocGroups extends Results<DocGroup> implements ResultGroups<DocResu
         if (maximumNumberOfResultsPerGroup < 0)
             maximumNumberOfResultsPerGroup = Integer.MAX_VALUE;
         List<DocGroup> truncatedGroups = new ArrayList<>();
-        for (DocGroup group: results) {
+        for (DocGroup group: getResults()) {
             List<DocResult> truncatedList = group.storedResults().window(0, maximumNumberOfResultsPerGroup).resultsList();
             DocGroup newGroup = DocGroup.fromList(queryInfo(), group.identity(), truncatedList, group.size(), group.totalTokens());
             truncatedGroups.add(newGroup);

--- a/core/src/main/java/nl/inl/blacklab/search/results/HitGroups.java
+++ b/core/src/main/java/nl/inl/blacklab/search/results/HitGroups.java
@@ -133,7 +133,7 @@ public class HitGroups extends Results<HitGroup> implements ResultGroups<Hit> {
             Integer groupSize = groupSizes.get(groupId);
             HitGroup group = HitGroup.fromList(queryInfo(), groupId, hitList, hits.capturedGroups(), groupSize);
             groups.put(groupId, group);
-            results.add(group);
+            getResults().add(group);
         }
     }
 
@@ -147,7 +147,7 @@ public class HitGroups extends Results<HitGroup> implements ResultGroups<Hit> {
             if (group.size() > largestGroupSize)
                 largestGroupSize = group.size();
             totalHits += group.size();
-            results.add(group);
+            getResults().add(group);
             this.groups.put(group.identity(), group);
             resultObjects += group.numberOfStoredResults() + 1;
         }
@@ -250,7 +250,7 @@ public class HitGroups extends Results<HitGroup> implements ResultGroups<Hit> {
         if (maximumNumberOfResultsPerGroup < 0)
             maximumNumberOfResultsPerGroup = Integer.MAX_VALUE;
         List<HitGroup> truncatedGroups = new ArrayList<>();
-        for (HitGroup group: results) {
+        for (HitGroup group: getResults()) {
             HitGroup newGroup = HitGroup.fromHits(group.identity(), group.storedResults().window(0, maximumNumberOfResultsPerGroup), group.size());
             truncatedGroups.add(newGroup);
         }

--- a/core/src/main/java/nl/inl/blacklab/search/results/Hits.java
+++ b/core/src/main/java/nl/inl/blacklab/search/results/Hits.java
@@ -145,7 +145,7 @@ public abstract class Hits extends Results<Hit> {
             }
             results.add(hit);
             if (capturedGroups != null)
-                capturedGroups.put(hit, this.capturedGroups.get(hit));
+                capturedGroups.put(hit, capturedGroups().get(hit));
             hitsCounted++;
         }
         
@@ -170,25 +170,25 @@ public abstract class Hits extends Results<Hit> {
      * The number of hits we've seen and counted so far. May be more than the number
      * of hits we've retrieved if that exceeds maxHitsToRetrieve.
      */
-    protected int hitsCounted = 0;
+    private int hitsCounted = 0;
 
     /**
      * The number of separate documents we've seen in the hits retrieved.
      */
-    protected int docsRetrieved = 0;
+    private int docsRetrieved = 0;
 
     /**
      * The number of separate documents we've counted so far (includes non-retrieved
      * hits).
      */
-    protected int docsCounted = 0;
+    private int docsCounted = 0;
 
     private ResultsStats docsStats = new ResultsStats() {
 
         @Override
         public boolean processedAtLeast(int lowerBound) {
             while (!doneProcessingAndCounting() && docsProcessedSoFar() < lowerBound) {
-                ensureResultsRead(results.size() + FETCH_HITS_MIN);
+                ensureResultsRead(getResults().size() + FETCH_HITS_MIN);
             }
             return docsProcessedSoFar() >= lowerBound;
         }
@@ -378,7 +378,7 @@ public abstract class Hits extends Results<Hit> {
     public Hits getHitsInDoc(int docid) {
         ensureAllResultsRead();
         List<Hit> hitsInDoc = new ArrayList<>();
-        for (Hit hit : results) {
+        for (Hit hit : getResults()) {
             if (hit.doc() == docid)
                 hitsInDoc.add(hit);
         }
@@ -406,7 +406,7 @@ public abstract class Hits extends Results<Hit> {
     
     protected int hitsCountedTotal() {
         ensureAllResultsRead();
-        return hitsCounted;
+        return getHitsCounted();
     }
 
     public ResultsStats docsStats() {
@@ -415,24 +415,24 @@ public abstract class Hits extends Results<Hit> {
 
     protected int docsProcessedTotal() {
         ensureAllResultsRead();
-        return docsRetrieved;
+        return getDocsRetrieved();
     }
 
     protected int docsCountedTotal() {
         ensureAllResultsRead();
-        return docsCounted;
+        return getDocsCounted();
     }
 
     protected int hitsCountedSoFar() {
-        return hitsCounted;
+        return getHitsCounted();
     }
 
     protected int docsCountedSoFar() {
-        return docsCounted;
+        return getDocsCounted();
     }
 
     protected int docsProcessedSoFar() {
-        return docsRetrieved;
+        return getDocsRetrieved();
     }
 
     @Override
@@ -450,7 +450,7 @@ public abstract class Hits extends Results<Hit> {
     
     public Hits window(Hit hit) {
         ensureAllResultsRead();
-        return window(results.indexOf(hit), 1);
+        return window(getResults().indexOf(hit), 1);
     }
     
     /**
@@ -496,7 +496,7 @@ public abstract class Hits extends Results<Hit> {
     }
 
     public boolean hasCapturedGroups() {
-        return capturedGroups != null;
+        return capturedGroups() != null;
     }
 
     // Hits display
@@ -535,4 +535,27 @@ public abstract class Hits extends Results<Hit> {
         return hitsProcessedSoFar();
     }
 
+    protected int getHitsCounted() {
+        return hitsCounted;
+    }
+
+    protected void setHitsCounted(int hitsCounted) {
+        this.hitsCounted = hitsCounted;
+    }
+
+    protected int getDocsRetrieved() {
+        return docsRetrieved;
+    }
+
+    protected void setDocsRetrieved(int docsRetrieved) {
+        this.docsRetrieved = docsRetrieved;
+    }
+
+    protected int getDocsCounted() {
+        return docsCounted;
+    }
+
+    protected void setDocsCounted(int docsCounted) {
+        this.docsCounted = docsCounted;
+    }
 }

--- a/core/src/main/java/nl/inl/blacklab/search/results/HitsList.java
+++ b/core/src/main/java/nl/inl/blacklab/search/results/HitsList.java
@@ -31,13 +31,13 @@ public class HitsList extends Hits {
      */
     protected HitsList(QueryInfo queryInfo, List<Hit> hits) {
         super(queryInfo);
-        this.results = hits == null ? new ArrayList<>() : hits;
-        hitsCounted = this.results.size();
+        this.setResults(hits == null ? new ArrayList<>() : hits);
+        setHitsCounted(this.getResults().size());
         int prevDoc = -1;
-        for (Hit h : this.results) {
+        for (Hit h : this.getResults()) {
             if (h.doc() != prevDoc) {
-                docsRetrieved++;
-                docsCounted++;
+                setDocsRetrieved(getDocsRetrieved() + 1);
+                setDocsCounted(getDocsCounted() + 1);
                 prevDoc = h.doc();
             }
         }
@@ -88,19 +88,19 @@ public class HitsList extends Hits {
     protected HitsList(QueryInfo queryInfo, List<Hit> results, WindowStats windowStats, SampleParameters sampleParameters,
             int hitsCounted, int docsRetrieved, int docsCounted, CapturedGroupsImpl capturedGroups) {
         super(queryInfo);
-        this.results = results;
+        this.setResults(results);
         this.windowStats = windowStats;
         this.sampleParameters = sampleParameters;
         
-        this.hitsCounted = hitsCounted;
-        this.docsRetrieved = docsRetrieved;
-        this.docsCounted = docsCounted;
+        this.setHitsCounted(hitsCounted);
+        this.setDocsRetrieved(docsRetrieved);
+        this.setDocsCounted(docsCounted);
         this.capturedGroups = capturedGroups;
     }
 
     @Override
     public String toString() {
-        return "HitsList#" + hitsObjId + " (hits.size()=" + results.size() + "; isWindow=" + isWindow() + ")";
+        return "HitsList#" + hitsObjId + " (hits.size()=" + getResults().size() + "; isWindow=" + isWindow() + ")";
     }
     
     /**

--- a/core/src/main/java/nl/inl/blacklab/search/results/Results.java
+++ b/core/src/main/java/nl/inl/blacklab/search/results/Results.java
@@ -103,10 +103,7 @@ public abstract class Results<T> implements SearchResult, Iterable<T> {
      */
     protected ThreadPauser threadPauser;
     
-    /**
-     * The results.
-     */
-    protected List<T> results;
+    private List<T> results;
 
     private ResultsStats resultsStats = new ResultsStats() {
         @Override
@@ -149,7 +146,7 @@ public abstract class Results<T> implements SearchResult, Iterable<T> {
         this.queryInfo = queryInfo;
 //        queryInfo.ensureResultsObjectIdSet(hitsObjId); // if we're the original query, set the id.
         threadPauser = ThreadPauser.create();
-        results = new ArrayList<>();
+        setResults(new ArrayList<>());
     }
 
     /**
@@ -265,7 +262,7 @@ public abstract class Results<T> implements SearchResult, Iterable<T> {
             public boolean hasNext() {
                 // Do we still have hits in the hits list?
                 ensureResultsRead(index + 2);
-                return results.size() >= index + 2;
+                return getResults().size() >= index + 2;
             }
         
             @Override
@@ -273,7 +270,7 @@ public abstract class Results<T> implements SearchResult, Iterable<T> {
                 // Check if there is a next, taking unread hits from Spans into account
                 if (hasNext()) {
                     index++;
-                    return results.get(index);
+                    return getResults().get(index);
                 }
                 throw new NoSuchElementException();
             }
@@ -294,9 +291,9 @@ public abstract class Results<T> implements SearchResult, Iterable<T> {
      */
     public synchronized T get(int i) {
         ensureResultsRead(i + 1);
-        if (i >= results.size())
+        if (i >= getResults().size())
             return null;
-        return results.get(i);
+        return getResults().get(i);
     }
     
     
@@ -381,7 +378,7 @@ public abstract class Results<T> implements SearchResult, Iterable<T> {
     
     protected boolean resultsProcessedAtLeast(int lowerBound) {
         ensureResultsRead(lowerBound);
-        return results.size() >= lowerBound;
+        return getResults().size() >= lowerBound;
     }
 
     /**
@@ -395,11 +392,11 @@ public abstract class Results<T> implements SearchResult, Iterable<T> {
 
     protected int resultsProcessedTotal() {
         ensureAllResultsRead();
-        return results.size();
+        return getResults().size();
     }
 
     protected int resultsProcessedSoFar() {
-        return results.size();
+        return getResults().size();
     }
 
     protected int resultsCountedSoFar() {
@@ -424,9 +421,9 @@ public abstract class Results<T> implements SearchResult, Iterable<T> {
      */
     protected List<T> resultsSubList(int fromIndex, int toIndex) {
         ensureResultsRead(toIndex);
-        if (toIndex > results.size())
-            toIndex = results.size();
-        return results.subList(fromIndex, toIndex);
+        if (toIndex > getResults().size())
+            toIndex = getResults().size();
+        return getResults().subList(fromIndex, toIndex);
     }
 
     /**
@@ -439,7 +436,7 @@ public abstract class Results<T> implements SearchResult, Iterable<T> {
      */
     protected List<T> resultsList() {
         ensureAllResultsRead();
-        return Collections.unmodifiableList(results);
+        return Collections.unmodifiableList(getResults());
     }
 
     /**
@@ -452,5 +449,15 @@ public abstract class Results<T> implements SearchResult, Iterable<T> {
      */
     public abstract boolean doneProcessingAndCounting();
 
-    
+
+    /**
+     * The results.
+     */
+    protected List<T> getResults() {
+        return results;
+    }
+
+    protected void setResults(List<T> results) {
+        this.results = results;
+    }
 }


### PR DESCRIPTION
I added a volatile variable so that other threads could see consistent results.

The interesting stuff is in `HitsFromQuery`.