### PR TITLE
Don't overwrite captures on hits with identical bounds

### DIFF
--- a/core/src/main/java/nl/inl/blacklab/search/results/Hit.java
+++ b/core/src/main/java/nl/inl/blacklab/search/results/Hit.java
@@ -13,10 +13,11 @@ public interface Hit extends Result<Hit> {
      * @param doc Lucene document id
      * @param start position of first word of the hit
      * @param end first word position after the hit
+     * @param index of the hit in query results
      * @return the hit
      */
-    static Hit create(int doc, int start, int end) {
-        return new HitImpl(doc, start, end);
+    static Hit create(int doc, int start, int end, int index) {
+        return new HitImpl(doc, start, end, index);
     }
     
     @Override
@@ -25,6 +26,9 @@ public interface Hit extends Result<Hit> {
             return 0;
         if (doc() == o.doc()) {
             if (start() == o.start()) {
+                if (end() == o.end()) {
+                    return index() - o.index();
+                }
                 return end() - o.end();
             }
             return start() - o.start();
@@ -49,5 +53,11 @@ public interface Hit extends Result<Hit> {
      * @return position of first word after the hit
      */
     int end();
+
+    /**
+     * Get the index of this hit.
+     * @return index of the hit in query results
+     */
+    int index();
 
 }

--- a/core/src/main/java/nl/inl/blacklab/search/results/HitImpl.java
+++ b/core/src/main/java/nl/inl/blacklab/search/results/HitImpl.java
@@ -39,17 +39,21 @@ public final class HitImpl implements Hit {
     /** Start of this hit's span (in word positions) */
     private int start;
 
+    private int index;
+
     /**
      * Construct a hit object
      *
      * @param doc the document
      * @param start start of the hit (word positions)
      * @param end end of the hit (word positions)
+     * @param index of the hit in query results
      */
-    protected HitImpl(int doc, int start, int end) {
+    protected HitImpl(int doc, int start, int end, int index) {
         this.doc = doc;
         this.start = start;
         this.end = end;
+        this.index = index;
     }
 
     @Override
@@ -68,12 +72,17 @@ public final class HitImpl implements Hit {
     }
 
     @Override
+    public int index() {
+        return index;
+    }
+
+    @Override
     public boolean equals(Object with) {
         if (this == with)
             return true;
         if (with instanceof Hit) {
             Hit o = (Hit) with;
-            return doc() == o.doc() && start() == o.start() && end() == o.end();
+            return doc() == o.doc() && start() == o.start() && end() == o.end() && index() == o.index();
         }
         return false;
     }
@@ -85,7 +94,13 @@ public final class HitImpl implements Hit {
     
     @Override
     public int hashCode() {
-        return (doc() * 17 + start()) * 31 + end();
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + doc();
+        result = prime * result + start();
+        result = prime * result + end();
+        result = prime * result + index();
+        return result;
     }
     
     // POSSIBLE FUTURE OPTIMIZATION

--- a/core/src/main/java/nl/inl/blacklab/search/results/HitsFromQuery.java
+++ b/core/src/main/java/nl/inl/blacklab/search/results/HitsFromQuery.java
@@ -323,7 +323,7 @@ public class HitsFromQuery extends Hits {
                         previousHitDoc = hitDoc;
                     }
                     if (!maxHitsProcessed) {
-                        Hit hit = Hit.create(currentSourceSpans.docID() + currentDocBase, currentSourceSpans.startPosition(), currentSourceSpans.endPosition());
+                        Hit hit = Hit.create(currentSourceSpans.docID() + currentDocBase, currentSourceSpans.startPosition(), currentSourceSpans.endPosition(), hitsResultsContext.results.size());
                         if (hitsResultsContext.capturedGroups != null) {
                             Span[] groups = new Span[hitQueryContext.numberOfCapturedGroups()];
                             hitQueryContext.getCapturedGroups(groups);

--- a/core/src/main/java/nl/inl/blacklab/search/results/HitsList.java
+++ b/core/src/main/java/nl/inl/blacklab/search/results/HitsList.java
@@ -11,7 +11,7 @@ public class HitsList extends Hits {
     private static List<Hit> createHitList(int[] doc, int[] start, int[] end) {
         List<Hit> hits = new ArrayList<>();
         for (int i = 0; i < doc.length; i++) {
-            hits.add(Hit.create(doc[i], start[i], end[i]));
+            hits.add(Hit.create(doc[i], start[i], end[i], i));
         }
         return hits;
     }

--- a/core/src/main/java/nl/inl/blacklab/search/results/SpansReader.java
+++ b/core/src/main/java/nl/inl/blacklab/search/results/SpansReader.java
@@ -181,7 +181,7 @@ public class SpansReader {
 
                     if (!spansFullyRead) {
                         // Count the hit and add it (unless we've reached the maximum number of hits we want)
-                        Hit hit = Hit.create(spans.docID() + docBase, spans.startPosition(), spans.endPosition());
+                        Hit hit = Hit.create(spans.docID() + docBase, spans.startPosition(), spans.endPosition(), 0); // TODO(lexion): fill in index if we ever use HitsInQueryParallel
                         if (capturedGroups != null) {
                             Span[] groups = new Span[hitQueryContext.numberOfCapturedGroups()];
                             hitQueryContext.getCapturedGroups(groups);

--- a/server/src/main/java/nl/inl/blacklab/server/requesthandlers/RequestHandlerDocSnippet.java
+++ b/server/src/main/java/nl/inl/blacklab/server/requesthandlers/RequestHandlerDocSnippet.java
@@ -81,7 +81,7 @@ public class RequestHandlerDocSnippet extends RequestHandler {
             snippetEnd = end + clampedWindow;
 //			throw new BadRequest("SNIPPET_TOO_LARGE", "Snippet too large. Maximum size for a snippet is " + searchMan.config().maxSnippetSize() + " words.");
         }
-        hit = Hit.create(luceneDocId, start, end);
+        hit = Hit.create(luceneDocId, start, end, 0);
         boolean origContent = searchParam.getString("usecontent").equals("orig");
         Hits hits = Hits.fromList(QueryInfo.create(blIndex), Arrays.asList(hit));
         getHitOrFragmentInfo(ds, hits, hit, wordsAroundHit, origContent, !isHit, null, new HashSet<>(this.getAnnotationsToWrite()));


### PR DESCRIPTION
This adds a new field, `index` to the `Hit` object, because otherwise identical hits can get overwritten in the capture group hash map.