### PR TITLE
Dont cache NumericDocValues

### DIFF
--- a/core/src/main/java/nl/inl/blacklab/search/lucene/DocFieldLengthGetter.java
+++ b/core/src/main/java/nl/inl/blacklab/search/lucene/DocFieldLengthGetter.java
@@ -22,7 +22,7 @@ import nl.inl.blacklab.search.indexmetadata.AnnotatedFieldNameUtil;
  * This is used by SpanQueryNot and SpanQueryExpansion to make sure we don't go
  * beyond the document end.
  */
-class DocFieldLengthGetter implements Closeable {
+class DocFieldLengthGetter {
     /**
      * We check some cache entries to see if document lengths were saved in the
      * index or not. (These days, they should always be saved, but we do this in
@@ -50,59 +50,10 @@ class DocFieldLengthGetter implements Closeable {
     /** Field name to check for the length of the field in tokens */
     private String lengthTokensFieldName;
 
-    /** Lengths may have been cached using FieldCache */
-    private NumericDocValues cachedFieldLengths;
-
-    private UninvertingReader uninv;
-
     public DocFieldLengthGetter(LeafReader reader, String fieldName) {
         this.reader = reader;
         this.fieldName = fieldName;
         lengthTokensFieldName = AnnotatedFieldNameUtil.lengthTokensField(fieldName);
-
-        if (fieldName.equals(Indexer.DEFAULT_CONTENTS_FIELD_NAME)) {
-            // Cache the lengths for this field to speed things up
-            try {
-                
-                cachedFieldLengths = reader.getNumericDocValues(lengthTokensFieldName);
-                if (cachedFieldLengths == null) {
-                    // Use UninvertingReader to simulate DocValues (slower)
-                    Map<String, UninvertingReader.Type> fields = new TreeMap<>();
-                    fields.put(lengthTokensFieldName, UninvertingReader.Type.INTEGER);
-                    @SuppressWarnings("resource")
-                    UninvertingReader uninv = new UninvertingReader(reader, fields);
-                    cachedFieldLengths = uninv.getNumericDocValues(lengthTokensFieldName);
-                }
-
-                // Check if the cache was retrieved OK
-                boolean allZeroes = true;
-                int numToCheck = Math.min(NUMBER_OF_CACHE_ENTRIES_TO_CHECK, reader.maxDoc());
-                for (int i = 0; i < numToCheck; i++) {
-                    // (NOTE: we don't check if document wasn't deleted, but that shouldn't matter here)
-                    if (cachedFieldLengths.get(i) != 0) {
-                        allZeroes = false;
-                        break;
-                    }
-                }
-                if (allZeroes) {
-                    // Tokens lengths weren't saved in the index, skip cache
-                    cachedFieldLengths = null;
-                }
-            } catch (IOException e) {
-                throw BlackLabRuntimeException.wrap(e);
-            }
-        }
-    }
-
-    @Override
-    public void close() {
-        if (uninv != null) {
-            try {
-                uninv.close();
-            } catch (IOException e) {
-                throw BlackLabRuntimeException.wrap(e);
-            }
-        }
     }
 
     /**
@@ -134,43 +85,15 @@ class DocFieldLengthGetter implements Closeable {
         if (useTestValues)
             return 6; // while testing, all documents have same length
 
-        if (cachedFieldLengths != null) {
-            return (int) cachedFieldLengths.get(doc);
-        }
-
-        if (!lookedForLengthField || lengthFieldIsStored) {
-            // We either know the field length is stored in the index,
-            // or we haven't checked yet and should do so now.
-            try {
-                Document document = reader.document(doc);
-                String strLength = document.get(lengthTokensFieldName);
-                lookedForLengthField = true;
-                if (strLength != null) {
-                    // Yes, found the field length stored in the index.
-                    // Parse and return it.
-                    lengthFieldIsStored = true;
-                    return Integer.parseInt(strLength);
-                }
-                // No, length field is not stored in the index. Always use term vector from now on.
-                lengthFieldIsStored = false;
-            } catch (IOException e) {
-                throw BlackLabRuntimeException.wrap(e);
-            }
-        }
-
-        // Calculate the total field length by adding all the term frequencies.
-        // (much slower, and not actually correct if there's not a value for every word. but should happen anymore, we should always have a length field nowadays)
         try {
-            Terms vector = reader.getTermVector(doc, AnnotatedFieldNameUtil.annotationField(fieldName, AnnotatedFieldNameUtil.WORD_ANNOT_NAME, "i"));
-            TermsEnum termsEnum = vector.iterator();
-            int termFreq = 0;
-            while (termsEnum.next() != null) {
-                termFreq += termsEnum.totalTermFreq();
+            NumericDocValues docValues = reader.getNumericDocValues(lengthTokensFieldName);
+            if (docValues != null) {
+                return (int)docValues.get(doc);
             }
-            return termFreq;
-
-        } catch (IOException e) {
-            throw BlackLabRuntimeException.wrap(e);
+        } catch (IOException ex) {
+            throw new BlackLabRuntimeException("Error getting NumericDocValues for " + lengthTokensFieldName, ex);
         }
+
+        throw new BlackLabRuntimeException("Can't find " + lengthTokensFieldName + " for doc " + doc);
     }
 }

--- a/core/src/main/java/nl/inl/blacklab/search/lucene/DocIntFieldGetter.java
+++ b/core/src/main/java/nl/inl/blacklab/search/lucene/DocIntFieldGetter.java
@@ -17,7 +17,7 @@ import nl.inl.blacklab.exceptions.BlackLabRuntimeException;
  *
  * This is used by SpanQueryFiSeq to get the forward index id (fiid).
  */
-public class DocIntFieldGetter implements Closeable {
+public class DocIntFieldGetter {
 
     /** The Lucene index reader, for querying field length */
     private LeafReader reader;
@@ -25,41 +25,9 @@ public class DocIntFieldGetter implements Closeable {
     /** Field name to check for the length of the field in tokens */
     private String intFieldName;
 
-    /** Lengths may have been cached using FieldCache */
-    private NumericDocValues docValues;
-
-    /** Reader for getting docValues even when they weren't explicitly indexed */
-    private UninvertingReader uninv;
-
     public DocIntFieldGetter(LeafReader reader, String fieldName) {
         this.reader = reader;
         intFieldName = fieldName;
-
-        // Cache the lengths for this field to speed things up
-        try {
-            docValues = reader.getNumericDocValues(intFieldName);
-            if (docValues == null) {
-                // Use UninvertingReader to simulate DocValues (slower)
-                Map<String, UninvertingReader.Type> fields = new TreeMap<>();
-                fields.put(intFieldName, UninvertingReader.Type.INTEGER);
-                @SuppressWarnings("resource")
-                UninvertingReader uninv = new UninvertingReader(reader, fields);
-                docValues = uninv.getNumericDocValues(intFieldName);
-            }
-        } catch (IOException e) {
-            throw BlackLabRuntimeException.wrap(e);
-        }
-    }
-
-    @Override
-    public void close() {
-        if (uninv != null) {
-            try {
-                uninv.close();
-            } catch (IOException e) {
-                throw BlackLabRuntimeException.wrap(e);
-            }
-        }
     }
 
     /**
@@ -69,26 +37,15 @@ public class DocIntFieldGetter implements Closeable {
      * @return value of the int field
      */
     public synchronized int getFieldValue(int doc) {
-
-        // Cached doc values?
-        if (docValues != null) {
-            return (int) docValues.get(doc);
-        }
-
-        // No; get the field value from the Document object.
-        // (Note that this code should never be executed, but just to be safe)
-        Document document;
         try {
-            document = reader.document(doc);
-        } catch (IOException e) {
-            throw BlackLabRuntimeException.wrap(e);
+            NumericDocValues docValues = reader.getNumericDocValues(intFieldName);
+            if (docValues != null) {
+                return (int)docValues.get(doc);
+            }
+        } catch (IOException ex) {
+            throw new BlackLabRuntimeException("Error getting NumericDocValues for " + intFieldName, ex);
         }
-        String strVal = document.get(intFieldName);
-        if (strVal != null) {
-            // Yes, found the field length stored in the index.
-            // Parse and return it.
-            return Integer.parseInt(strVal);
-        }
+
         throw new BlackLabRuntimeException("Can't find " + intFieldName + " for doc " + doc);
     }
 }


### PR DESCRIPTION
Lucene already caches it in thread-local storage