### PR TITLE
Introduces logging and metrics changes

### DIFF
--- a/core/src/main/java/nl/inl/blacklab/searches/AbstractSearch.java
+++ b/core/src/main/java/nl/inl/blacklab/searches/AbstractSearch.java
@@ -13,6 +13,7 @@ import nl.inl.blacklab.exceptions.InterruptedSearch;
 import nl.inl.blacklab.exceptions.InvalidQuery;
 import nl.inl.blacklab.search.results.QueryInfo;
 import nl.inl.blacklab.search.results.SearchResult;
+import org.apache.logging.log4j.ThreadContext;
 
 /**
  * Abstract base class for all Search implementations,
@@ -31,8 +32,10 @@ public abstract class AbstractSearch<R extends SearchResult> implements Search<R
     
     @Override
     public Future<R> executeAsync() {
+        final String requestId = ThreadContext.get("requestId");
         return getFromCache(this, () -> {
             try {
+                ThreadContext.put("requestId", requestId);
                 return executeInternal();
             } catch (InvalidQuery e) {
                 throw new CompletionException(e);

--- a/pom.xml
+++ b/pom.xml
@@ -118,8 +118,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.0</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>1.9</source>
+                    <target>1.9</target>
                 </configuration>
             </plugin>
 

--- a/server/src/main/java/nl/inl/blacklab/server/BlackLabServer.java
+++ b/server/src/main/java/nl/inl/blacklab/server/BlackLabServer.java
@@ -105,7 +105,7 @@ public class BlackLabServer extends HttpServlet {
 
             // Open log database
             try {
-                //Default instrumentation logging, logs at the trace level.
+                // Default instrumentation logging, logs at the trace level.
                 logDatabase = new ConsoleLogDatabase();
                 searchManager.setLogDatabase(logDatabase);
                 String sqliteDatabase = searchManager.config().getLog().getSqliteDatabase();

--- a/server/src/main/java/nl/inl/blacklab/server/BlackLabServer.java
+++ b/server/src/main/java/nl/inl/blacklab/server/BlackLabServer.java
@@ -105,7 +105,7 @@ public class BlackLabServer extends HttpServlet {
 
             // Open log database
             try {
-                logDatabase = new ConsoleLogDatabase(BlackLabServer.logger);
+                logDatabase = new ConsoleLogDatabase();
                 searchManager.setLogDatabase(logDatabase);
                 String sqliteDatabase = searchManager.config().getLog().getSqliteDatabase();
                 if (sqliteDatabase != null) {

--- a/server/src/main/java/nl/inl/blacklab/server/BlackLabServer.java
+++ b/server/src/main/java/nl/inl/blacklab/server/BlackLabServer.java
@@ -11,18 +11,16 @@ import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.List;
-import java.util.Map;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import nl.inl.blacklab.requestlogging.LogLevel;
-import nl.inl.blacklab.requestlogging.SearchLogger;
-import nl.inl.blacklab.search.results.SearchResult;
-import nl.inl.blacklab.server.logging.*;
-import nl.inl.blacklab.server.search.BlsCacheEntry;
+import nl.inl.blacklab.server.logging.ConsoleLogDatabase;
+import nl.inl.blacklab.server.logging.LogDatabase;
+import nl.inl.blacklab.server.logging.LogDatabaseDummy;
+import nl.inl.blacklab.server.logging.LogDatabaseImpl;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 

--- a/server/src/main/java/nl/inl/blacklab/server/BlackLabServer.java
+++ b/server/src/main/java/nl/inl/blacklab/server/BlackLabServer.java
@@ -105,6 +105,7 @@ public class BlackLabServer extends HttpServlet {
 
             // Open log database
             try {
+                //Default instrumentation logging, logs at the trace level.
                 logDatabase = new ConsoleLogDatabase();
                 searchManager.setLogDatabase(logDatabase);
                 String sqliteDatabase = searchManager.config().getLog().getSqliteDatabase();

--- a/server/src/main/java/nl/inl/blacklab/server/BlackLabServer.java
+++ b/server/src/main/java/nl/inl/blacklab/server/BlackLabServer.java
@@ -107,6 +107,8 @@ public class BlackLabServer extends HttpServlet {
 
             // Open log database
             try {
+                logDatabase = new ConsoleLogDatabase(BlackLabServer.logger);
+                searchManager.setLogDatabase(logDatabase);
                 String sqliteDatabase = searchManager.config().getLog().getSqliteDatabase();
                 if (sqliteDatabase != null) {
                     File dbFile = new File(sqliteDatabase);
@@ -114,53 +116,6 @@ public class BlackLabServer extends HttpServlet {
                     Class.forName("org.sqlite.JDBC");
                     logDatabase = new LogDatabaseImpl(url);
                     searchManager.setLogDatabase(logDatabase);
-                } else {
-                    LogDatabase ld = new LogDatabase() {
-                        @Override
-                        public List<Request> getRequests(long from, long to) {
-                            return null;
-                        }
-
-                        @Override
-                        public List<CacheStats> getCacheStats(long from, long to) {
-                            return null;
-                        }
-
-                        @Override
-                        public void close() throws IOException {
-
-                        }
-
-                        @Override
-                        public SearchLogger addRequest(String corpus, String type, Map<String, String[]> parameters) {
-                            return new SearchLogger() {
-                                @Override
-                                public void log(LogLevel level, String line) {
-                                    if (level != LogLevel.BASIC) {
-                                        return;
-                                    }
-                                   BlackLabServer.logger.info(line);
-                                }
-
-                                @Override
-                                public void setResultsFound(int resultsFound) {
-
-                                }
-
-                                @Override
-                                public void close() throws IOException {
-
-                                }
-                            };
-                        }
-
-                        @Override
-                        public void addCacheInfo(List<BlsCacheEntry<? extends SearchResult>> snapshot, int numberOfSearches, int numberRunning, int numberPaused, long sizeBytes, long freeMemoryBytes, long largestEntryBytes, int oldestEntryAgeSec) {
-
-                        }
-                    };
-                    searchManager.setLogDatabase(ld);
-                    this.logDatabase = ld;
                 }
             } catch (IOException | ClassNotFoundException e) {
                 throw new RuntimeException("Error opening log database", e);

--- a/server/src/main/java/nl/inl/blacklab/server/BlackLabServer.java
+++ b/server/src/main/java/nl/inl/blacklab/server/BlackLabServer.java
@@ -17,10 +17,6 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import nl.inl.blacklab.server.logging.ConsoleLogDatabase;
-import nl.inl.blacklab.server.logging.LogDatabase;
-import nl.inl.blacklab.server.logging.LogDatabaseDummy;
-import nl.inl.blacklab.server.logging.LogDatabaseImpl;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -36,6 +32,10 @@ import nl.inl.blacklab.server.datastream.DataStream;
 import nl.inl.blacklab.server.exceptions.BlsException;
 import nl.inl.blacklab.server.exceptions.ConfigurationException;
 import nl.inl.blacklab.server.exceptions.InternalServerError;
+import nl.inl.blacklab.server.logging.ConsoleLogDatabase;
+import nl.inl.blacklab.server.logging.LogDatabase;
+import nl.inl.blacklab.server.logging.LogDatabaseDummy;
+import nl.inl.blacklab.server.logging.LogDatabaseImpl;
 import nl.inl.blacklab.server.requesthandlers.ElementNames;
 import nl.inl.blacklab.server.requesthandlers.RequestHandler;
 import nl.inl.blacklab.server.requesthandlers.Response;

--- a/server/src/main/java/nl/inl/blacklab/server/Metrics.java
+++ b/server/src/main/java/nl/inl/blacklab/server/Metrics.java
@@ -217,7 +217,7 @@ public class Metrics {
     }
 
     public static <T> ToDoubleFunction<T> toDoubleFn(ToLongFunction<T> intGenerator) {
-        return  (T obj) -> (float) intGenerator.applyAsLong(obj);
+        return  (T obj) -> (double) intGenerator.applyAsLong(obj);
     }
     public static <T> Gauge createGauge(String name, String description, Tags tags, T obj, ToDoubleFunction<T> f) {
         return Gauge.builder(name, obj, f)

--- a/server/src/main/java/nl/inl/blacklab/server/Metrics.java
+++ b/server/src/main/java/nl/inl/blacklab/server/Metrics.java
@@ -2,9 +2,7 @@ package nl.inl.blacklab.server;
 
 import io.micrometer.cloudwatch2.CloudWatchConfig;
 import io.micrometer.cloudwatch2.CloudWatchMeterRegistry;
-import io.micrometer.core.instrument.Clock;
-import io.micrometer.core.instrument.Tags;
-import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.*;
 import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.binder.jvm.*;
 import io.micrometer.core.instrument.binder.system.ProcessorMetrics;
@@ -34,8 +32,12 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.*;
+import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
+import java.util.function.ToDoubleFunction;
+import java.util.function.ToIntFunction;
+import java.util.function.ToLongFunction;
 
 public class Metrics {
     private static final Logger logger = LogManager.getLogger(Metrics.class);
@@ -211,6 +213,16 @@ public class Metrics {
                 .tags(tags)
                 .publishPercentiles(0.5, 0.9,0.99)
                 .publishPercentileHistogram()
+                .register(Metrics.metricsRegistry);
+    }
+
+    public static <T> ToDoubleFunction<T> toDoubleFn(ToLongFunction<T> intGenerator) {
+        return  (T obj) -> (float) intGenerator.applyAsLong(obj);
+    }
+    public static <T> Gauge createGauge(String name, String description, Tags tags, T obj, ToDoubleFunction<T> f) {
+        return Gauge.builder(name, obj, f)
+                .description(description)
+                .tags(tags)
                 .register(Metrics.metricsRegistry);
     }
 }

--- a/server/src/main/java/nl/inl/blacklab/server/Metrics.java
+++ b/server/src/main/java/nl/inl/blacklab/server/Metrics.java
@@ -211,8 +211,6 @@ public class Metrics {
         return Timer.builder(name)
                 .description(description)
                 .tags(tags)
-                .publishPercentiles(0.5, 0.9,0.99)
-                .publishPercentileHistogram()
                 .register(Metrics.metricsRegistry);
     }
 

--- a/server/src/main/java/nl/inl/blacklab/server/Metrics.java
+++ b/server/src/main/java/nl/inl/blacklab/server/Metrics.java
@@ -2,9 +2,15 @@ package nl.inl.blacklab.server;
 
 import io.micrometer.cloudwatch2.CloudWatchConfig;
 import io.micrometer.cloudwatch2.CloudWatchMeterRegistry;
-import io.micrometer.core.instrument.*;
+import io.micrometer.core.instrument.Clock;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.Timer;
-import io.micrometer.core.instrument.binder.jvm.*;
+import io.micrometer.core.instrument.binder.jvm.JvmGcMetrics;
+import io.micrometer.core.instrument.binder.jvm.JvmHeapPressureMetrics;
+import io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics;
+import io.micrometer.core.instrument.binder.jvm.JvmThreadMetrics;
 import io.micrometer.core.instrument.binder.system.ProcessorMetrics;
 import io.micrometer.core.instrument.binder.tomcat.TomcatMetrics;
 import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
@@ -26,17 +32,18 @@ import software.amazon.awssdk.services.ec2.model.DescribeTagsResponse;
 import software.amazon.awssdk.services.ec2.model.Filter;
 import software.amazon.awssdk.services.ec2.model.TagDescription;
 
-
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.time.Duration;
-import java.util.*;
-import java.util.concurrent.BlockingQueue;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
 import java.util.function.ToDoubleFunction;
-import java.util.function.ToIntFunction;
 import java.util.function.ToLongFunction;
 
 public class Metrics {

--- a/server/src/main/java/nl/inl/blacklab/server/Metrics.java
+++ b/server/src/main/java/nl/inl/blacklab/server/Metrics.java
@@ -3,6 +3,7 @@ package nl.inl.blacklab.server;
 import io.micrometer.cloudwatch2.CloudWatchConfig;
 import io.micrometer.cloudwatch2.CloudWatchMeterRegistry;
 import io.micrometer.core.instrument.Clock;
+import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.binder.jvm.*;

--- a/server/src/main/java/nl/inl/blacklab/server/Metrics.java
+++ b/server/src/main/java/nl/inl/blacklab/server/Metrics.java
@@ -214,7 +214,7 @@ public class Metrics {
         return true;
     }
 
-    public static Timer creatTimer(String name, String description, Iterable<Tag> tags){
+    public static Timer createTimer(String name, String description, Iterable<Tag> tags){
         return Timer.builder(name)
                 .description(description)
                 .tags(tags)

--- a/server/src/main/java/nl/inl/blacklab/server/Metrics.java
+++ b/server/src/main/java/nl/inl/blacklab/server/Metrics.java
@@ -3,7 +3,8 @@ package nl.inl.blacklab.server;
 import io.micrometer.cloudwatch2.CloudWatchConfig;
 import io.micrometer.cloudwatch2.CloudWatchMeterRegistry;
 import io.micrometer.core.instrument.Clock;
-import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.binder.jvm.*;
 import io.micrometer.core.instrument.binder.system.ProcessorMetrics;
 import io.micrometer.core.instrument.binder.tomcat.TomcatMetrics;
@@ -201,6 +202,15 @@ public class Metrics {
             }
         });
         return true;
+    }
+
+    public static Timer creatTimer(String name, String description, Iterable<Tag> tags){
+        return Timer.builder(name)
+                .description(description)
+                .tags(tags)
+                .publishPercentiles(0.5, 0.9,0.99)
+                .publishPercentileHistogram()
+                .register(Metrics.metricsRegistry);
     }
 }
 

--- a/server/src/main/java/nl/inl/blacklab/server/logging/ConsoleLogDatabase.java
+++ b/server/src/main/java/nl/inl/blacklab/server/logging/ConsoleLogDatabase.java
@@ -1,0 +1,62 @@
+package nl.inl.blacklab.server.logging;
+
+import nl.inl.blacklab.requestlogging.LogLevel;
+import nl.inl.blacklab.requestlogging.SearchLogger;
+import nl.inl.blacklab.search.results.SearchResult;
+import nl.inl.blacklab.server.search.BlsCacheEntry;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import org.apache.logging.log4j.Logger;
+
+public class ConsoleLogDatabase implements LogDatabase {
+        private final Logger logger;
+
+        public ConsoleLogDatabase(Logger logger) {
+                this.logger = logger;
+        }
+
+        @Override
+        public List<Request> getRequests(long from, long to) {
+                return null;
+        }
+
+        @Override
+        public List<CacheStats> getCacheStats(long from, long to) {
+                return null;
+        }
+
+        @Override
+        public void close() throws IOException {
+
+        }
+
+        @Override
+        public SearchLogger addRequest(String corpus, String type, Map<String, String[]> parameters) {
+                return new SearchLogger() {
+                        @Override
+                        public void log(LogLevel level, String line) {
+                                if (level != LogLevel.BASIC) {
+                                        return;
+                                }
+                                ConsoleLogDatabase.this.logger.info(line);
+                        }
+
+                        @Override
+                        public void setResultsFound(int resultsFound) {
+
+                        }
+
+                        @Override
+                        public void close() throws IOException {
+
+                        }
+                };
+        }
+
+        @Override
+        public void addCacheInfo(List<BlsCacheEntry<? extends SearchResult>> snapshot, int numberOfSearches, int numberRunning, int numberPaused, long sizeBytes, long freeMemoryBytes, long largestEntryBytes, int oldestEntryAgeSec) {
+
+        }
+}

--- a/server/src/main/java/nl/inl/blacklab/server/logging/ConsoleLogDatabase.java
+++ b/server/src/main/java/nl/inl/blacklab/server/logging/ConsoleLogDatabase.java
@@ -8,55 +8,50 @@ import nl.inl.blacklab.server.search.BlsCacheEntry;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+
+import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 public class ConsoleLogDatabase implements LogDatabase {
-        private final Logger logger;
+    private static final Logger LOGGER = LogManager.getLogger(ConsoleLogDatabase.class);
 
-        public ConsoleLogDatabase(Logger logger) {
-                this.logger = logger;
-        }
+    @Override
+    public List<Request> getRequests(long from, long to) {
+        return null;
+    }
 
-        @Override
-        public List<Request> getRequests(long from, long to) {
-                return null;
-        }
+    @Override
+    public List<CacheStats> getCacheStats(long from, long to) {
+        return null;
+    }
 
-        @Override
-        public List<CacheStats> getCacheStats(long from, long to) {
-                return null;
-        }
+    @Override
+    public void close() throws IOException {
 
-        @Override
-        public void close() throws IOException {
+    }
 
-        }
+    @Override
+    public SearchLogger addRequest(String corpus, String type, Map<String, String[]> parameters) {
+        return new SearchLogger() {
+            @Override
+            public void log(LogLevel level, String line) {
+                ConsoleLogDatabase.LOGGER.trace(line);
+            }
 
-        @Override
-        public SearchLogger addRequest(String corpus, String type, Map<String, String[]> parameters) {
-                return new SearchLogger() {
-                        @Override
-                        public void log(LogLevel level, String line) {
-                                if (level != LogLevel.BASIC) {
-                                        return;
-                                }
-                                ConsoleLogDatabase.this.logger.info(line);
-                        }
+            @Override
+            public void setResultsFound(int resultsFound) {
 
-                        @Override
-                        public void setResultsFound(int resultsFound) {
+            }
 
-                        }
+            @Override
+            public void close() throws IOException {
 
-                        @Override
-                        public void close() throws IOException {
+            }
+        };
+    }
 
-                        }
-                };
-        }
+    @Override
+    public void addCacheInfo(List<BlsCacheEntry<? extends SearchResult>> snapshot, int numberOfSearches, int numberRunning, int numberPaused, long sizeBytes, long freeMemoryBytes, long largestEntryBytes, int oldestEntryAgeSec) {
 
-        @Override
-        public void addCacheInfo(List<BlsCacheEntry<? extends SearchResult>> snapshot, int numberOfSearches, int numberRunning, int numberPaused, long sizeBytes, long freeMemoryBytes, long largestEntryBytes, int oldestEntryAgeSec) {
-
-        }
+    }
 }

--- a/server/src/main/java/nl/inl/blacklab/server/logging/ConsoleLogDatabase.java
+++ b/server/src/main/java/nl/inl/blacklab/server/logging/ConsoleLogDatabase.java
@@ -12,6 +12,11 @@ import java.util.Map;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+/**
+ * ConsoleLogDatabase provides an implementation to LogDatabase, that simply
+ * logs internal blacklab operations to stdout.
+ * ConsoleLogDatabase is a lightweight tracing class to enable debugging of search requests.
+ */
 public class ConsoleLogDatabase implements LogDatabase {
     private static final Logger LOGGER = LogManager.getLogger(ConsoleLogDatabase.class);
 

--- a/server/src/main/java/nl/inl/blacklab/server/logging/ConsoleLogDatabase.java
+++ b/server/src/main/java/nl/inl/blacklab/server/logging/ConsoleLogDatabase.java
@@ -16,6 +16,7 @@ import org.apache.logging.log4j.Logger;
  * ConsoleLogDatabase provides an implementation to LogDatabase, that simply
  * logs internal blacklab operations to stdout.
  * ConsoleLogDatabase is a lightweight tracing class to enable debugging of search requests.
+ * This class logs in the trace level. To see its output set the loglevel to trace.
  */
 public class ConsoleLogDatabase implements LogDatabase {
     private static final Logger LOGGER = LogManager.getLogger(ConsoleLogDatabase.class);

--- a/server/src/main/java/nl/inl/blacklab/server/requesthandlers/RequestHandler.java
+++ b/server/src/main/java/nl/inl/blacklab/server/requesthandlers/RequestHandler.java
@@ -459,7 +459,7 @@ public abstract class RequestHandler {
     }
 
     protected String getAnnRequestId() {
-        String requestId= request.getHeader(ANN_REQUEST_ID_HEADER_NAME);
+        String requestId = request.getHeader(ANN_REQUEST_ID_HEADER_NAME);
         if (requestId == null) {
             requestId = "unknown";
         }

--- a/server/src/main/java/nl/inl/blacklab/server/requesthandlers/RequestHandler.java
+++ b/server/src/main/java/nl/inl/blacklab/server/requesthandlers/RequestHandler.java
@@ -2,8 +2,16 @@ package nl.inl.blacklab.server.requesthandlers;
 
 import java.io.IOException;
 import java.lang.reflect.Constructor;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 import javax.servlet.http.HttpServletRequest;

--- a/server/src/main/java/nl/inl/blacklab/server/requesthandlers/RequestHandler.java
+++ b/server/src/main/java/nl/inl/blacklab/server/requesthandlers/RequestHandler.java
@@ -466,12 +466,12 @@ public abstract class RequestHandler {
         return  requestId;
     }
     protected Optional<String> getRuleId() {
-        String ruleId= request.getHeader(ANN_RULE_ID_HEADER_NAME);
+        String ruleId = request.getHeader(ANN_RULE_ID_HEADER_NAME);
         return Optional.ofNullable(ruleId);
     }
 
     protected void setRequestIds() {
-        // In search requests request id is acquired from the rule id header
+        // During search requests request id is acquired from the rule id header
         String reqId = getRuleId().orElse(
             Base64.getUrlEncoder().encodeToString(UUID.randomUUID().toString().getBytes()));
         ThreadContext.put("requestId", String.format("%s/%s", getAnnRequestId(), reqId));

--- a/server/src/main/java/nl/inl/blacklab/server/requesthandlers/RequestHandler.java
+++ b/server/src/main/java/nl/inl/blacklab/server/requesthandlers/RequestHandler.java
@@ -10,6 +10,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -81,6 +82,8 @@ public abstract class RequestHandler {
 
     // Header for Ann's requests IDs
     private static final String ANN_REQUEST_ID_HEADER_NAME = "X-Request-ID";
+    // Header for Ann's rule IDs
+    private static final String ANN_RULE_ID_HEADER_NAME = "X-Ann-Rule-ID";
 
     /** The available request handlers by name */
     static Map<String, Class<? extends RequestHandler>> availableHandlers;
@@ -455,14 +458,23 @@ public abstract class RequestHandler {
 
     }
 
-    private void setRequestIds() {
+    protected String getAnnRequestId() {
         String requestId= request.getHeader(ANN_REQUEST_ID_HEADER_NAME);
         if (requestId == null) {
             requestId = "unknown";
         }
-        String b64uuid = Base64.getUrlEncoder().encodeToString(UUID.randomUUID().toString().getBytes());
-        requestId = String.format("%s/%s", requestId, b64uuid);
-        ThreadContext.put("requestId", requestId);
+        return  requestId;
+    }
+    protected Optional<String> getRuleId() {
+        String ruleId= request.getHeader(ANN_RULE_ID_HEADER_NAME);
+        return Optional.ofNullable(ruleId);
+    }
+
+    protected void setRequestIds() {
+        // In search requests request id is acquired from the rule id header
+        String reqId = getRuleId().orElse(
+            Base64.getUrlEncoder().encodeToString(UUID.randomUUID().toString().getBytes()));
+        ThreadContext.put("requestId", String.format("%s/%s", getAnnRequestId(), reqId));
     }
 
     public void cleanup() {

--- a/server/src/main/java/nl/inl/blacklab/server/requesthandlers/RequestHandlerHits.java
+++ b/server/src/main/java/nl/inl/blacklab/server/requesthandlers/RequestHandlerHits.java
@@ -1,6 +1,9 @@
 package nl.inl.blacklab.server.requesthandlers;
 
-import java.util.*;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
@@ -135,9 +138,9 @@ public class RequestHandlerHits extends RequestHandler {
 
             // Since we're going to always launch a totals count anyway, just do it right away
             // then construct a window on top of the total
-            hits = searchMan.search(user, searchParam.hitsSample()); //blocking
+            hits = searchMan.search(user, searchParam.hitsSample());
             job = searchMan.searchNonBlocking(user, searchParam.hitsCount()); // always launch totals nonblocking!
-            docsCount = searchMan.search(user, searchParam.docsCount()); //blocks
+            docsCount = searchMan.search(user, searchParam.docsCount());
             try {
                 hitsCount = (ResultCount) job.get();
             } catch (InterruptedException | ExecutionException e) {

--- a/server/src/main/java/nl/inl/blacklab/server/requesthandlers/RequestHandlerHits.java
+++ b/server/src/main/java/nl/inl/blacklab/server/requesthandlers/RequestHandlerHits.java
@@ -202,7 +202,7 @@ public class RequestHandlerHits extends RequestHandler {
                     "Total time to execute Hits search request", numberOfDocs);
             timerMetric.record(totalTime, TimeUnit.MILLISECONDS);
         }
-        logger.info(String.format("Total execution time is: %d and docs: %d", totalTime, numDocs));
+        logger.info(String.format("Total execution time is: %d and docs: %d",  totalTime, numDocs));
 
         // TODO timing is now broken because we always retrieve total and use a window on top of it,
         // so we can no longer differentiate the total time from the time to retrieve the requested window

--- a/server/src/main/java/nl/inl/blacklab/server/requesthandlers/RequestHandlerHits.java
+++ b/server/src/main/java/nl/inl/blacklab/server/requesthandlers/RequestHandlerHits.java
@@ -201,12 +201,6 @@ public class RequestHandlerHits extends RequestHandler {
 
         long totalTime = job.threwException() ? -1 : job.timeUserWaited();
         int numDocs = searchParam.getNumberOfDocs();
-        if (totalTime >= 0) {
-            Tags numberOfDocs = Tags.of("numberOfDocs", String.format("%d", numDocs));
-            Timer timerMetric = Metrics.createTimer("TotalTimeHits",
-                    "Total time to execute Hits search request", numberOfDocs);
-            timerMetric.record(totalTime, TimeUnit.MILLISECONDS);
-        }
         logger.info("For rule:{}. Total execution time is:{} ms and docs:{}", ruleId, totalTime, numDocs);
 
         // TODO timing is now broken because we always retrieve total and use a window on top of it,

--- a/server/src/main/java/nl/inl/blacklab/server/requesthandlers/RequestHandlerHits.java
+++ b/server/src/main/java/nl/inl/blacklab/server/requesthandlers/RequestHandlerHits.java
@@ -200,6 +200,7 @@ public class RequestHandlerHits extends RequestHandler {
         Timer timerMetric = Metrics.creatTimer("TotalTimeHits",
                 "Total time to execute Hits search request", numberOfDocs);
         timerMetric.record(totalTime, TimeUnit.MILLISECONDS);
+        logger.info(String.format("Total execution time is: %d and docs: %d", totalTime, numDocs));
 
         // TODO timing is now broken because we always retrieve total and use a window on top of it,
         // so we can no longer differentiate the total time from the time to retrieve the requested window

--- a/server/src/main/java/nl/inl/blacklab/server/requesthandlers/RequestHandlerHits.java
+++ b/server/src/main/java/nl/inl/blacklab/server/requesthandlers/RequestHandlerHits.java
@@ -63,10 +63,17 @@ import nl.inl.blacklab.server.search.BlsCacheEntry;
 public class RequestHandlerHits extends RequestHandler {
 
     private static final Logger logger = LogManager.getLogger(RequestHandlerHits.class);
+    private static final String ANN_RULE_ID_HEADER_NAME = "X-Ann-Rule-ID";
+    private String ruleId;
 
     public RequestHandlerHits(BlackLabServer servlet, HttpServletRequest request, User user, String indexName,
             String urlResource, String urlPathPart) {
         super(servlet, request, user, indexName, urlResource, urlPathPart);
+        ruleId = request.getHeader(ANN_RULE_ID_HEADER_NAME);
+        if (ruleId == null) {
+            ruleId = "unknown";
+        }
+        logger.info("Will start search for rule id: {}", ruleId);
     }
 
 
@@ -205,7 +212,7 @@ public class RequestHandlerHits extends RequestHandler {
                     "Total time to execute Hits search request", numberOfDocs);
             timerMetric.record(totalTime, TimeUnit.MILLISECONDS);
         }
-        logger.info(String.format("Total execution time is: %d and docs: %d",  totalTime, numDocs));
+        logger.info("For rule:{}. Total execution time is:{} ms and docs:{}", ruleId, totalTime, numDocs);
 
         // TODO timing is now broken because we always retrieve total and use a window on top of it,
         // so we can no longer differentiate the total time from the time to retrieve the requested window

--- a/server/src/main/java/nl/inl/blacklab/server/requesthandlers/RequestHandlerHits.java
+++ b/server/src/main/java/nl/inl/blacklab/server/requesthandlers/RequestHandlerHits.java
@@ -11,7 +11,6 @@ import javax.servlet.http.HttpServletRequest;
 
 import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.Timer;
-import nl.inl.blacklab.requestlogging.LogLevel;
 import nl.inl.blacklab.server.Metrics;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -63,16 +62,12 @@ import nl.inl.blacklab.server.search.BlsCacheEntry;
 public class RequestHandlerHits extends RequestHandler {
 
     private static final Logger logger = LogManager.getLogger(RequestHandlerHits.class);
-    private static final String ANN_RULE_ID_HEADER_NAME = "X-Ann-Rule-ID";
-    private String ruleId;
+    private final String ruleId;
 
     public RequestHandlerHits(BlackLabServer servlet, HttpServletRequest request, User user, String indexName,
             String urlResource, String urlPathPart) {
         super(servlet, request, user, indexName, urlResource, urlPathPart);
-        ruleId = request.getHeader(ANN_RULE_ID_HEADER_NAME);
-        if (ruleId == null) {
-            ruleId = "unknown";
-        }
+        ruleId = getRuleId().orElse("unknown");
         logger.info("Will start search for rule id: {}", ruleId);
     }
 
@@ -208,7 +203,7 @@ public class RequestHandlerHits extends RequestHandler {
         int numDocs = searchParam.getNumberOfDocs();
         if (totalTime >= 0) {
             Tags numberOfDocs = Tags.of("numberOfDocs", String.format("%d", numDocs));
-            Timer timerMetric = Metrics.creatTimer("TotalTimeHits",
+            Timer timerMetric = Metrics.createTimer("TotalTimeHits",
                     "Total time to execute Hits search request", numberOfDocs);
             timerMetric.record(totalTime, TimeUnit.MILLISECONDS);
         }

--- a/server/src/main/java/nl/inl/blacklab/server/requesthandlers/RequestHandlerHits.java
+++ b/server/src/main/java/nl/inl/blacklab/server/requesthandlers/RequestHandlerHits.java
@@ -196,10 +196,12 @@ public class RequestHandlerHits extends RequestHandler {
 
         long totalTime = job.threwException() ? -1 : job.timeUserWaited();
         int numDocs = searchParam.getNumberOfDocs();
-        Tags numberOfDocs = Tags.of("numberOfDocs", String.format("%d", numDocs));
-        Timer timerMetric = Metrics.creatTimer("TotalTimeHits",
-                "Total time to execute Hits search request", numberOfDocs);
-        timerMetric.record(totalTime, TimeUnit.MILLISECONDS);
+        if (totalTime >= 0) {
+            Tags numberOfDocs = Tags.of("numberOfDocs", String.format("%d", numDocs));
+            Timer timerMetric = Metrics.creatTimer("TotalTimeHits",
+                    "Total time to execute Hits search request", numberOfDocs);
+            timerMetric.record(totalTime, TimeUnit.MILLISECONDS);
+        }
         logger.info(String.format("Total execution time is: %d and docs: %d", totalTime, numDocs));
 
         // TODO timing is now broken because we always retrieve total and use a window on top of it,

--- a/server/src/main/java/nl/inl/blacklab/server/requesthandlers/SearchParameters.java
+++ b/server/src/main/java/nl/inl/blacklab/server/requesthandlers/SearchParameters.java
@@ -242,7 +242,9 @@ public class SearchParameters {
         if (StringUtils.isBlank(filter)) {
             return 0;
         }
+        System.out.println(filter);
         Pattern patt =  Pattern.compile("(docId:\\p{Graph}+)+");
+        //Pattern patt =  Pattern.compile("docId:(\\p{Graph}+)+");
         List<String> allResults = new ArrayList<>();
         for (MatchResult result : patt.matcher(filter).results()
                 .collect(Collectors.toList())) {

--- a/server/src/main/java/nl/inl/blacklab/server/requesthandlers/SearchParameters.java
+++ b/server/src/main/java/nl/inl/blacklab/server/requesthandlers/SearchParameters.java
@@ -243,11 +243,12 @@ public class SearchParameters {
             return 0;
         }
         Pattern patt =  Pattern.compile("(docId:\\p{Graph}+)+");
-        List<String> allDocs = patt.matcher(filter)
-                .results()
-                .map(MatchResult::group)
-                .collect(Collectors.toList());
-        return allDocs.size();
+        List<String> allResults = new ArrayList<>();
+        for (MatchResult result : patt.matcher(filter).results()
+                .collect(Collectors.toList())) {
+           allResults.add(result.group());
+        }
+        return allResults.size();
     }
 
     public long getLong(String name) {

--- a/server/src/main/java/nl/inl/blacklab/server/requesthandlers/SearchParameters.java
+++ b/server/src/main/java/nl/inl/blacklab/server/requesthandlers/SearchParameters.java
@@ -12,6 +12,10 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.regex.MatchResult;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -231,6 +235,19 @@ public class SearchParameters {
             logger.debug("Illegal integer value for parameter '" + name + "': " + value);
             return 0;
         }
+    }
+
+    public int getNumberOfDocs() {
+        String filter = getString("filter");
+        if (StringUtils.isBlank(filter)) {
+            return 0;
+        }
+        Pattern patt =  Pattern.compile("(docId:\\p{Graph}+)+");
+        List<String> allDocs = patt.matcher(filter)
+                .results()
+                .map(MatchResult::group)
+                .collect(Collectors.toList());
+        return allDocs.size();
     }
 
     public long getLong(String name) {

--- a/server/src/main/java/nl/inl/blacklab/server/requesthandlers/SearchParameters.java
+++ b/server/src/main/java/nl/inl/blacklab/server/requesthandlers/SearchParameters.java
@@ -237,15 +237,14 @@ public class SearchParameters {
         }
     }
 
+    private static final Pattern DOC_NUM_PATT = Pattern.compile("([a-f0-9-]+[)|\\s])+");
     public int getNumberOfDocs() {
         String filter = getString("filter");
         if (StringUtils.isBlank(filter)) {
             return 0;
         }
-        //Experiment with this regex as well "(docId:\\p{Graph}+)+"
-        Pattern patt = Pattern.compile("([a-f0-9-]+[)|\\s])+");
         List<String> allResults = new ArrayList<>();
-        for (MatchResult result : patt.matcher(filter).results()
+        for (MatchResult result : DOC_NUM_PATT.matcher(filter).results()
                 .collect(Collectors.toList())) {
            allResults.add(result.group());
         }

--- a/server/src/main/java/nl/inl/blacklab/server/requesthandlers/SearchParameters.java
+++ b/server/src/main/java/nl/inl/blacklab/server/requesthandlers/SearchParameters.java
@@ -237,20 +237,6 @@ public class SearchParameters {
         }
     }
 
-    private static final Pattern DOC_NUM_PATT = Pattern.compile("([a-f0-9-]+[)|\\s])+");
-    public int getNumberOfDocs() {
-        String filter = getString("filter");
-        if (StringUtils.isBlank(filter)) {
-            return 0;
-        }
-        List<String> allResults = new ArrayList<>();
-        for (MatchResult result : DOC_NUM_PATT.matcher(filter).results()
-                .collect(Collectors.toList())) {
-           allResults.add(result.group());
-        }
-        return allResults.size();
-    }
-
     public long getLong(String name) {
         String value = getString(name);
         try {

--- a/server/src/main/java/nl/inl/blacklab/server/requesthandlers/SearchParameters.java
+++ b/server/src/main/java/nl/inl/blacklab/server/requesthandlers/SearchParameters.java
@@ -242,7 +242,7 @@ public class SearchParameters {
         if (StringUtils.isBlank(filter)) {
             return 0;
         }
-        //Pattern patt =  Pattern.compile("(docId:\\p{Graph}+)+");
+        //Experiment with this regex as well "(docId:\\p{Graph}+)+"
         Pattern patt = Pattern.compile("([a-f0-9-]+[)|\\s])+");
         List<String> allResults = new ArrayList<>();
         for (MatchResult result : patt.matcher(filter).results()

--- a/server/src/main/java/nl/inl/blacklab/server/requesthandlers/SearchParameters.java
+++ b/server/src/main/java/nl/inl/blacklab/server/requesthandlers/SearchParameters.java
@@ -242,9 +242,8 @@ public class SearchParameters {
         if (StringUtils.isBlank(filter)) {
             return 0;
         }
-        System.out.println(filter);
-        Pattern patt =  Pattern.compile("(docId:\\p{Graph}+)+");
-        //Pattern patt =  Pattern.compile("docId:(\\p{Graph}+)+");
+        //Pattern patt =  Pattern.compile("(docId:\\p{Graph}+)+");
+        Pattern patt = Pattern.compile("([a-f0-9-]+[)|\\s])+");
         List<String> allResults = new ArrayList<>();
         for (MatchResult result : patt.matcher(filter).results()
                 .collect(Collectors.toList())) {

--- a/server/src/main/java/nl/inl/blacklab/server/search/SearchManager.java
+++ b/server/src/main/java/nl/inl/blacklab/server/search/SearchManager.java
@@ -19,12 +19,8 @@ import nl.inl.blacklab.server.jobs.User;
 import nl.inl.blacklab.server.logging.LogDatabase;
 import nl.inl.blacklab.server.requesthandlers.SearchParameters;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Queue;
-import java.util.concurrent.*;
-import java.util.function.ToDoubleFunction;
-import java.util.function.ToIntFunction;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ForkJoinPool;
 
 public class SearchManager {
 
@@ -76,16 +72,7 @@ public class SearchManager {
     }
 
     private void startMonitoringOfThreadPools(BlackLabEngine blackLab) {
-        //publishInitExecServiceQueueSize(blackLab.initializationExecutorService());
         publishSearchExecutorsQueueSize(blackLab.searchExecutorService());
-    }
-
-    private void publishInitExecServiceQueueSize(ExecutorService initializationExecutorService) {
-        assert initializationExecutorService instanceof ThreadPoolExecutor;
-        ThreadPoolExecutor executorService = (ThreadPoolExecutor) initializationExecutorService;
-        Collection<?> queue =  executorService.getQueue();
-        Metrics.createGauge("InitializationExecutorQueueLen", "A metric that tracks the queue length of the " +
-                "initializationExecutorService", Tags.empty(), queue, Metrics.toDoubleFn(Collection::size));
     }
 
     private void publishSearchExecutorsQueueSize(ExecutorService searchExecutorService) {

--- a/server/src/main/resources/log4j2.xml
+++ b/server/src/main/resources/log4j2.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Configuration status="WARN">
+<Configuration status="DEBUG">
 	<Appenders>
 		<Console name="Console" target="SYSTEM_OUT">
 			<!-- DEFAULT:<PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n" />  -->
-			<PatternLayout pattern="%d{HH:mm:ss.SSS} [%-20t] %-35c{2.} %-5p %m%n" />
+			<PatternLayout pattern="%d{HH:mm:ss.SSS} [%-20t] %-35c{2.} %-5p rid=%X{requestId} %m%n" />
 		</Console>
 	</Appenders>
 	<Loggers>

--- a/server/src/main/resources/log4j2.xml
+++ b/server/src/main/resources/log4j2.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Configuration status="DEBUG">
+<Configuration status="WARN">
 	<Appenders>
 		<Console name="Console" target="SYSTEM_OUT">
 			<!-- DEFAULT:<PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n" />  -->


### PR DESCRIPTION
This PR introduces
- `requestId` an id to keep track of each of the request blacklab serves on: In the past all requests id were the ann request id. Now the requestId contains the ann request id as well as unique string.
- Metrics for the executor services that backs search requests, as well as metrics for search total time.
- Logging implementation to log console. This plus the unique request ids should  allow us to follow a search job until is completion. It is very verbose so it is going to the trace.
- Some other logging: doc numbers in a request and the total time.
