### PR TITLE
improves exception reporting

### DIFF
--- a/server/src/main/java/nl/inl/blacklab/server/requesthandlers/Response.java
+++ b/server/src/main/java/nl/inl/blacklab/server/requesthandlers/Response.java
@@ -62,8 +62,7 @@ public class Response {
     // Highest internal error code so far: 32
 
     public static int internalError(DataStream ds, Exception e, boolean debugMode, String code) {
-        logger.debug("INTERNAL ERROR " + code + ":");
-        e.printStackTrace();
+        logger.error("INTERNAL ERROR " + code + ":", e);
         ds.internalError(e, debugMode, code);
         return HttpServletResponse.SC_INTERNAL_SERVER_ERROR;
     }


### PR DESCRIPTION
In a multithreaded environment relying on `Exception::printStackTrace()` could yield interlaced logging lines. Better to rely on the logging framework to atomically output  log line.