### PR TITLE
Convert HitsResultsContext to HitsArrays

### DIFF
--- a/engine/src/main/java/nl/inl/blacklab/search/results/Contexts.java
+++ b/engine/src/main/java/nl/inl/blacklab/search/results/Contexts.java
@@ -70,7 +70,7 @@ public class Contexts implements Iterable<int[]> {
         // Get punctuation context
         int[][] punctContext = null;
         if (punctForwardIndex != null) {
-            punctContext = getContextWordsSingleDocument(hits.hitsArrays, 0, hits.size(), wordsAroundHit, Arrays.asList(punctForwardIndex), Arrays.asList(fiidLookups.get(punctForwardIndex.annotation())));
+            punctContext = getContextWordsSingleDocument(hits.getHitsArrays(), 0, hits.size(), wordsAroundHit, Arrays.asList(punctForwardIndex), Arrays.asList(fiidLookups.get(punctForwardIndex.annotation())));
         }
         Terms punctTerms = punctForwardIndex == null ? null : punctForwardIndex.terms();
 
@@ -89,13 +89,13 @@ public class Contexts implements Iterable<int[]> {
                 attrName[i] = e.getKey();
                 attrFI[i] = e.getValue();
                 attrTerms[i] = attrFI[i].terms();
-                attrContext[i] = getContextWordsSingleDocument(hits.hitsArrays, 0, hits.size(), wordsAroundHit, Arrays.asList(attrFI[i]), Arrays.asList(fiidLookups.get(attrName[i])));
+                attrContext[i] = getContextWordsSingleDocument(hits.getHitsArrays(), 0, hits.size(), wordsAroundHit, Arrays.asList(attrFI[i]), Arrays.asList(fiidLookups.get(attrName[i])));
                 i++;
             }
         }
 
         // Get word context
-        int[][] wordContext = getContextWordsSingleDocument(hits.hitsArrays, 0, hits.size(), wordsAroundHit, Arrays.asList(forwardIndex), Arrays.asList(fiidLookups.get(forwardIndex.annotation())));
+        int[][] wordContext = getContextWordsSingleDocument(hits.getHitsArrays(), 0, hits.size(), wordsAroundHit, Arrays.asList(forwardIndex), Arrays.asList(fiidLookups.get(forwardIndex.annotation())));
         Terms terms = forwardIndex.terms();
 
         // Make the concordances from the context
@@ -298,7 +298,7 @@ public class Contexts implements Iterable<int[]> {
         // Group hits per document
 
         // setup first iteration
-        HitsArrays ha = hits.hitsArrays;
+        HitsArrays ha = hits.getHitsArrays();
         final int size = ha.size(); // TODO ugly, might be slow because of required locking
         int prevDoc = size == 0 ? -1 : ha.doc(0);
         int firstHitInCurrentDoc = 0;

--- a/engine/src/main/java/nl/inl/blacklab/search/results/HitsFromQueryParallel.java
+++ b/engine/src/main/java/nl/inl/blacklab/search/results/HitsFromQueryParallel.java
@@ -411,7 +411,7 @@ public class HitsFromQueryParallel extends Hits {
                     weight,
                     leafReaderContext,
                     this.hitQueryContext,
-                    this.hitsArrays,
+                        this.getHitsArrays(),
                     this.capturedGroups,
                     this.globalDocsProcessed,
                     this.globalDocsCounted,
@@ -455,7 +455,7 @@ public class HitsFromQueryParallel extends Hits {
     protected void ensureResultsRead(int number) {
         final int clampedNumber = number = number < 0 ? maxHitsToCount : Math.min(number, maxHitsToCount);
 
-        if (allSourceSpansFullyRead || (hitsArrays.size() >= clampedNumber)) {
+        if (allSourceSpansFullyRead || (getHitsArrays().size() >= clampedNumber)) {
             return;
         }
 
@@ -471,7 +471,7 @@ public class HitsFromQueryParallel extends Hits {
              * So instead poll our own state, then if we're still missing results after that just count them ourselves
              */
             while (!ensureHitsReadLock.tryLock()) {
-                if (allSourceSpansFullyRead || (hitsArrays.size() >= clampedNumber)) {
+                if (allSourceSpansFullyRead || (getHitsArrays().size() >= clampedNumber)) {
                     return;
                 }
 

--- a/engine/src/main/java/nl/inl/blacklab/search/results/HitsList.java
+++ b/engine/src/main/java/nl/inl/blacklab/search/results/HitsList.java
@@ -25,9 +25,9 @@ public class HitsList extends Hits {
         super(queryInfo, hits);
         this.capturedGroups = capturedGroups;
 
-        hitsCounted = this.hitsArrays.size();
+        hitsCounted = this.getHitsArrays().size();
         int prevDoc = -1;
-        MutableIntIterator it = this.hitsArrays.docs().intIterator();
+        MutableIntIterator it = this.getHitsArrays().docs().intIterator();
         while (it.hasNext()) {
             int docId = it.next();
             if (docId != prevDoc) {


### PR DESCRIPTION
Based on this change: https://github.com/lexionai/BlackLab/commit/ea645eebc0237cedb19d1bacb145f6a1a8004bec#diff-7372a19dec8c7a856813dbcef0841f90c33ccf4eadd6036fc16d37afac5b4a8a, it was a straightforward swap of the results list to HitsArrays, so hopefully this fix will work as well, though I haven't built or tested it.

