### PR TITLE
Enables canonical output for index yaml parsing

### DIFF
--- a/core/src/main/java/nl/inl/util/Json.java
+++ b/core/src/main/java/nl/inl/util/Json.java
@@ -82,7 +82,7 @@ public class Json {
      */
     public static String getString(JsonNode parent, String name, String defVal) {
         if (parent.has(name))
-            return parent.get(name).textValue();
+            return parent.get(name).asText(defVal);
         return defVal;
     }
 

--- a/core/src/main/java/nl/inl/util/Json.java
+++ b/core/src/main/java/nl/inl/util/Json.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
 
 /**
  * Supports reading/writing JSON and YAML files.
@@ -25,7 +26,7 @@ public class Json {
 
     static private ObjectMapper jsonObjectMapper;
 
-    static private JsonFactory yamlFactory;
+    static private YAMLFactory yamlFactory;
 
     static private ObjectMapper yamlObjectMapper;
 
@@ -40,6 +41,7 @@ public class Json {
         jsonObjectMapper.configure(JsonParser.Feature.STRICT_DUPLICATE_DETECTION, true);
 
         yamlFactory = new YAMLFactory();
+        yamlFactory.configure(YAMLGenerator.Feature.CANONICAL_OUTPUT, true);
         yamlObjectMapper = new ObjectMapper(yamlFactory);
         yamlObjectMapper.configure(JsonParser.Feature.STRICT_DUPLICATE_DETECTION, true);
     }
@@ -94,8 +96,9 @@ public class Json {
      * @return the boolean value
      */
     public static boolean getBoolean(JsonNode parent, String name, boolean defVal) {
-        if (parent.has(name))
-            return parent.get(name).booleanValue();
+        if (parent.has(name)) {
+            return parent.get(name).asBoolean(defVal);
+        }
         return defVal;
     }
 
@@ -110,7 +113,7 @@ public class Json {
      */
     public static long getLong(ObjectNode parent, String name, long defVal) {
         if (parent.has(name))
-            return parent.get(name).longValue();
+            return parent.get(name).asLong(defVal);
         return defVal;
     }
 
@@ -125,7 +128,7 @@ public class Json {
      */
     public static int getInt(ObjectNode parent, String name, int defVal) {
         if (parent.has(name))
-            return parent.get(name).intValue();
+            return parent.get(name).asInt(defVal);
         return defVal;
     }
 
@@ -143,7 +146,7 @@ public class Json {
         List<String> result = new ArrayList<>();
         if (arr != null) {
             for (int i = 0; i < arr.size(); i++) {
-                result.add(arr.get(i).textValue());
+                result.add(arr.get(i).asText());
             }
         }
         return result;

--- a/core/src/test/java/nl/inl/util/TestXmlUtil.java
+++ b/core/src/test/java/nl/inl/util/TestXmlUtil.java
@@ -15,6 +15,7 @@
  *******************************************************************************/
 package nl.inl.util;
 
+import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -25,6 +26,8 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.StringWriter;
+import java.util.HashMap;
+import java.util.Map;
 
 public class TestXmlUtil {
 
@@ -58,35 +61,17 @@ public class TestXmlUtil {
         Assert.assertEquals("test\u00A0test\u00A0", XmlUtil.xmlToPlainText("test test ", true));
     }
 
-    @Test(expected = JsonParseException.class)
-    public void testYamlMultiLineNotCanonical() throws Exception {
-        String key = "SomeKey:\n\nA";
-        ObjectMapper jsonMapper = Json.getJsonObjectMapper();
-        ObjectNode jsonRoot = jsonMapper.createObjectNode();
-        jsonRoot.put(key, 302);
-
-        YAMLFactory yamlFactory = new YAMLFactory();
-        ObjectMapper yamlObjectMapper = new ObjectMapper(yamlFactory);
-        yamlObjectMapper.configure(JsonParser.Feature.STRICT_DUPLICATE_DETECTION, true);
-        StringWriter swriter = new StringWriter();
-
-        yamlObjectMapper.writeValue(swriter, jsonRoot);
-
-        ObjectMapper readMapper =  Json.getYamlObjectMapper();
-        ObjectNode readJsonRoot = (ObjectNode) readMapper.readTree(swriter.toString());
-        Assert.assertEquals(readJsonRoot.get(key).asInt(),302 );
-    }
-
     @Test
     public void testYamlMultiLineWithCanonical() throws Exception {
-        String key = "SomeKey:\n\nA";
+        String []keys = new String[]{"SomeKeyString:\n\nAnotherLine", "SomeKeyInteger:\n\nAnotherLine","SomeKeyBoolean:\n\nAnotherLine", "Simple"};
         ObjectMapper jsonMapper = Json.getJsonObjectMapper();
         ObjectNode jsonRoot = jsonMapper.createObjectNode();
-        jsonRoot.put(key, 302);
+        jsonRoot.put(keys[0], "valstring");
+        jsonRoot.put(keys[1], 20);
+        jsonRoot.put(keys[2], true);
+        jsonRoot.put(keys[3], "simple");
 
-        YAMLFactory yamlFactory = new YAMLFactory();
-        yamlFactory.configure(YAMLGenerator.Feature.CANONICAL_OUTPUT, true);
-        ObjectMapper yamlObjectMapper = new ObjectMapper(yamlFactory);
+        ObjectMapper yamlObjectMapper = Json.getYamlObjectMapper();
         yamlObjectMapper.configure(JsonParser.Feature.STRICT_DUPLICATE_DETECTION, true);
         StringWriter swriter = new StringWriter();
 
@@ -94,7 +79,10 @@ public class TestXmlUtil {
 
         ObjectMapper readMapper =  Json.getYamlObjectMapper();
         ObjectNode readJsonRoot = (ObjectNode) readMapper.readTree(swriter.toString());
-        Assert.assertEquals(readJsonRoot.get(key).asInt(),302 );
+        Assert.assertEquals("valstring", Json.getString(readJsonRoot, keys[0], ""));
+        Assert.assertEquals(20, Json.getInt(readJsonRoot, keys[1], 0));
+        Assert.assertEquals(true, Json.getBoolean(readJsonRoot, keys[2], false));
+        Assert.assertEquals("simple", Json.getString(readJsonRoot, keys[3], ""));
     }
 
 


### PR DESCRIPTION
This is to workaround a bug when handling multiline yaml keys than contain a :