### PR TITLE
Adds request id to searches, fixes race condition

### DIFF
--- a/server/src/main/java/nl/inl/blacklab/server/search/ResultsCache.java
+++ b/server/src/main/java/nl/inl/blacklab/server/search/ResultsCache.java
@@ -3,10 +3,10 @@ package nl.inl.blacklab.server.search;
 import com.github.benmanes.caffeine.cache.AsyncLoadingCache;
 import com.github.benmanes.caffeine.cache.CacheLoader;
 import com.github.benmanes.caffeine.cache.Caffeine;
-import com.github.benmanes.caffeine.cache.LoadingCache;
 import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.binder.cache.CaffeineCacheMetrics;
+import nl.inl.blacklab.exceptions.BlackLabRuntimeException;
 import nl.inl.blacklab.search.BlackLabIndex;
 import nl.inl.blacklab.search.results.SearchResult;
 import nl.inl.blacklab.searches.CacheInfoDataStream;
@@ -15,31 +15,35 @@ import nl.inl.blacklab.searches.SearchCache;
 import nl.inl.blacklab.searches.SearchCacheEntry;
 import nl.inl.blacklab.searches.SearchCacheEntryFromFuture;
 import nl.inl.blacklab.server.config.BLSConfig;
-import nl.inl.blacklab.server.config.BLSConfigCache;
 import nl.inl.blacklab.server.logging.LogDatabase;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.ThreadContext;
-import org.checkerframework.checker.nullness.qual.Nullable;
 
-import java.util.Map;
 import java.util.concurrent.*;
 
 public class ResultsCache implements SearchCache {
     private static final Logger logger = LogManager.getLogger(ResultsCache.class);
     private static final String CACHE_NAME_FOR_METRICS = "blacklab-results-cache";
     private final ExecutorService threadPool;
-    private final AsyncLoadingCache<Search<? extends SearchResult>, SearchResult> searchCache;
-    private final ConcurrentHashMap<Search<? extends SearchResult>, Future<? extends SearchResult>> runningJobs = new ConcurrentHashMap<>();
+    private final AsyncLoadingCache<SearchInfoWrapper, SearchResult> searchCache;
+    private final ConcurrentHashMap<Search<? extends SearchResult>, Future<CacheEntryWithResults<? extends SearchResult>>> runningJobs = new ConcurrentHashMap<>();
 
 
     public static class CacheEntryWithResults<T extends SearchResult> extends SearchCacheEntry<T> {
 
         private final T results;
+        private final long runTime;
 
-        public CacheEntryWithResults(T results) {
+        public CacheEntryWithResults(T results, long runTime) {
             this.results = results;
+            this.runTime = runTime;
         }
+
+        public T getResults() {
+            return results;
+        }
+
         @Override
         public boolean wasStarted() {
             return true;
@@ -51,7 +55,7 @@ public class ResultsCache implements SearchCache {
 
         @Override
         public long timeUserWaitedMs() {
-            return -1;
+            return runTime;
         }
 
         @Override
@@ -83,27 +87,62 @@ public class ResultsCache implements SearchCache {
         public T get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
             return results;
         }
+
+    }
+
+    private static final class SearchInfoWrapper {
+        private final Search<? extends SearchResult>  search;
+        private final String requestId;
+
+        public SearchInfoWrapper(Search<? extends SearchResult> search, String requestId) {
+            this.search = search;
+            this.requestId = requestId;
+        }
+
+        public Search<? extends SearchResult> getSearch() {
+            return search;
+        }
+
+        public String getRequestId() {
+            return requestId;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()){
+                return false;
+            }
+            SearchInfoWrapper that = (SearchInfoWrapper) o;
+            return search.equals(that.search);
+        }
+
+        @Override
+        public int hashCode() {
+            return search.hashCode();
+        }
     }
 
     public ResultsCache(BLSConfig config, ExecutorService threadPool, LogDatabase logDatabase)  {
         this.threadPool = threadPool;
 
-        CacheLoader<Search<? extends SearchResult>, SearchResult> cacheLoader = new CacheLoader<Search<? extends SearchResult>, SearchResult>() {
+        CacheLoader<SearchInfoWrapper, SearchResult> cacheLoader = new CacheLoader<SearchInfoWrapper, SearchResult>() {
             @Override
-            public @Nullable SearchResult load(Search<?> search) throws Exception {
-                ThreadContext.put("requestId", Integer.toHexString(search.hashCode()));
-                long start = System.currentTimeMillis();
-                Future<? extends SearchResult> job;
-                if (runningJobs.containsKey(search)) {
-                    job = runningJobs.get(search);
-                } else {
-                    job = ResultsCache.this.threadPool.submit(search::executeInternal);
-                    runningJobs.put(search, job);
-                }
-                SearchResult searchResult = job.get();
-                logger.warn("Search time is: {}", System.currentTimeMillis() - start);
-                runningJobs.remove(search);
-                return searchResult;
+            public SearchResult load(final SearchInfoWrapper searchWrapper) throws Exception {
+                final String requestId = searchWrapper.getRequestId();
+                ThreadContext.put("requestId", requestId);
+                Future<CacheEntryWithResults<? extends SearchResult>> job = runningJobs.computeIfAbsent(searchWrapper.getSearch(), (search) -> ResultsCache.this.threadPool.submit(() -> {
+                    ThreadContext.put("requestId", requestId);
+                    final long startTime = System.currentTimeMillis();
+                    SearchResult results = search.executeInternal();
+                    return new CacheEntryWithResults<>(results, System.currentTimeMillis() - startTime);
+                }));
+                CacheEntryWithResults<? extends SearchResult> searchResult = job.get();
+                logger.warn("Internal search time is: {}", searchResult.timeUserWaitedMs());
+                runningJobs.remove(searchWrapper.getSearch());
+                return searchResult.getResults();
             }
         };
 
@@ -120,27 +159,27 @@ public class ResultsCache implements SearchCache {
     @Override
     public <T extends SearchResult> SearchCacheEntry<T> getAsync(final Search<T> search, final boolean allowQueue) {
         try {
-            CompletableFuture<SearchResult> resultsFuture = searchCache.get(search);
+            CompletableFuture<SearchResult> resultsFuture = searchCache.get(new SearchInfoWrapper(search, ThreadContext.get("requestId")));
             return new SearchCacheEntryFromFuture(resultsFuture);
-        }catch (Exception ex) {
-            ex.printStackTrace();
-            throw ex;
+        } catch (Exception ex) {
+            throw BlackLabRuntimeException.wrap(ex);
         }
     }
 
     @Override
     public <T extends SearchResult> SearchCacheEntry<T> remove(Search<T> search) {
-        if (searchCache.asMap().containsKey(search)) {
-            SearchResult searchResult = searchCache.synchronous().get(search);
-            searchCache.synchronous().invalidate(search);
-            return new CacheEntryWithResults(searchResult);
+        SearchInfoWrapper searchWrapper = new SearchInfoWrapper(search, null);
+        SearchResult searchResult = searchCache.synchronous().asMap().remove(searchWrapper);
+        if (searchResult != null) {
+            return new CacheEntryWithResults(searchResult, -1);
         }
         return null;
     }
 
     @Override
     public void removeSearchesForIndex(BlackLabIndex index) {
-        searchCache.asMap().keySet().removeIf(s -> s.queryInfo().index() == index);
+        logger.info("Removing searches for index: {}", index.name());
+        searchCache.asMap().keySet().removeIf(s -> s.getSearch().queryInfo().index() == index);
     }
 
     @Override


### PR DESCRIPTION
Re-establishes request ids when performing queries, fixes narrow chance of double run when choosing to start a query. Properly captures elapsed time when executing queries.