### PR TITLE
Add option to omit empty captures.

### DIFF
--- a/core/src/site/markdown/configuration-files.md
+++ b/core/src/site/markdown/configuration-files.md
@@ -142,9 +142,16 @@ parameters:
 
     # By default, should we include the grouped hits in
     # grouped responses? If false, just include group 
-    # identity and size. Can be overridden using the
-    # "includegroupcontents" parameter.
+    # identity and size. Defaults to false. Can be overridden 
+    # using the "includegroupcontents" parameter.
     writeHitsAndDocsInGroupedHits: false
+
+    # If we're capturing part of our matches, should
+    # we include empty captures? This can happen when the
+    # clause to capture is optional, e.g. A:[]?
+    # Defaults to false. Can be overridden using the 
+    # "omitemptycaptures" parameter.
+    omitEmptyCaptures: false
 
 
 

--- a/docker/blacklab-server-FULL-EXAMPLE.yaml
+++ b/docker/blacklab-server-FULL-EXAMPLE.yaml
@@ -77,6 +77,13 @@ parameters:
     # "includegroupcontents" parameter.
     writeHitsAndDocsInGroupedHits: false
 
+    # If we're capturing part of our matches, should
+    # we include empty captures? This can happen when the
+    # clause to capture is optional, e.g. A:[]?
+    # Defaults to false. Can be overridden using the
+    # "omitemptycaptures" parameter.
+    omitEmptyCaptures: false
+
 
 
 #  Settings for job caching.

--- a/engine/src/main/java/nl/inl/blacklab/search/BlackLabIndexImpl.java
+++ b/engine/src/main/java/nl/inl/blacklab/search/BlackLabIndexImpl.java
@@ -669,17 +669,6 @@ public class BlackLabIndexImpl implements BlackLabIndexWriter {
                 }
             }
         }
-
-        reader.addReaderClosedListener(reader -> {
-            String indexName = "unknown";
-            if (BlackLabIndexImpl.this.blackLab != null) {
-                BlackLabIndex blIndex =  BlackLabIndexImpl.this.blackLab.indexFromReader(reader);
-                indexName = blIndex != null ? blIndex.name() : "unknown";
-            }
-            ByteArrayOutputStream outstream = new ByteArrayOutputStream();
-            new Exception("Stack trace").printStackTrace(new PrintStream(outstream));
-            logger.debug("Index: {} closed from: {}", indexName, outstream.toString("UTF-8"));
-        });
     }
 
     @Override

--- a/engine/src/main/java/nl/inl/blacklab/search/Span.java
+++ b/engine/src/main/java/nl/inl/blacklab/search/Span.java
@@ -21,9 +21,12 @@ public class Span {
         return end;
     }
 
+    public int length() {
+        return end - start;
+    }
+
     @Override
     public String toString() {
         return start + "-" + end;
     }
-
 }

--- a/engine/src/main/java/nl/inl/blacklab/search/results/CapturedGroups.java
+++ b/engine/src/main/java/nl/inl/blacklab/search/results/CapturedGroups.java
@@ -21,7 +21,18 @@ public interface CapturedGroups {
      * @param hit hit to get groups for
      * @return groups
      */
-    Span[] get(Hit hit);
+    default Span[] get(Hit hit) {
+        return get(hit, false);
+    }
+
+    /**
+     * Get the captured groups.
+     *
+     * @param hit hit to get groups for
+     * @param omitEmpty if true, instead of a Span with length 0, null will be returned (default: false)
+     * @return groups
+     */
+    Span[] get(Hit hit, boolean omitEmpty);
 
     /**
      * Get a map of the captured groups.
@@ -31,7 +42,20 @@ public interface CapturedGroups {
      * @param hit hit to get groups for
      * @return groups
      */
-    Map<String, Span> getMap(Hit hit);
+    default Map<String, Span> getMap(Hit hit) {
+        return getMap(hit, false);
+    }
+
+    /**
+     * Get a map of the captured groups.
+     *
+     * Relatively slow. If you care about performance, prefer {@link #get(Hit)}.
+     *
+     * @param hit hit to get groups for
+     * @param omitEmpty if true, instead of a Span with length 0, null will be returned (default: false)
+     * @return groups
+     */
+    Map<String, Span> getMap(Hit hit, boolean omitEmpty);
 
     /**
      * Add groups for a hit

--- a/engine/src/main/java/nl/inl/blacklab/search/results/CapturedGroupsImpl.java
+++ b/engine/src/main/java/nl/inl/blacklab/search/results/CapturedGroupsImpl.java
@@ -73,10 +73,27 @@ public class CapturedGroupsImpl implements CapturedGroups {
      * @return groups
      */
     @Override
-    public Span[] get(Hit hit) {
+    public Span[] get(Hit hit, boolean omitEmpty) {
         if (capturedGroups == null)
             return null;
-        return capturedGroups.get(hit);
+        Span[] groups = capturedGroups.get(hit);
+        if (omitEmpty) {
+            // We don't want any Spans where start and end are equal. Replace them with null instead.
+            Span[] withoutEmpty = null;
+            for (int i = 0; i < groups.length; i++) {
+                if (groups[i].length() == 0) {
+                    if (withoutEmpty == null) {
+                        withoutEmpty = new Span[groups.length];
+                        System.arraycopy(groups, 0, withoutEmpty, 0, groups.length);
+                    }
+                    withoutEmpty[i] = null;
+                }
+            }
+            if (withoutEmpty != null)
+                return withoutEmpty;
+        }
+        // We don't mind empty captures, or there are none.
+        return groups;
     }
 
     /**
@@ -88,7 +105,7 @@ public class CapturedGroupsImpl implements CapturedGroups {
      * @return groups
      */
     @Override
-    public Map<String, Span> getMap(Hit hit) {
+    public Map<String, Span> getMap(Hit hit, boolean omitEmpty) {
         if (capturedGroups == null)
             return null;
         List<String> names = names();
@@ -97,7 +114,8 @@ public class CapturedGroupsImpl implements CapturedGroups {
             return null;
         Map<String, Span> result = new TreeMap<>(); // TreeMap to maintain group ordering
         for (int i = 0; i < names.size(); i++) {
-            result.put(names.get(i), groups[i]);
+            if (!omitEmpty || groups[i].length() > 0)
+                result.put(names.get(i), groups[i]);
         }
         return result;
     }

--- a/server/src/main/java/nl/inl/blacklab/server/config/BLSConfigParameters.java
+++ b/server/src/main/java/nl/inl/blacklab/server/config/BLSConfigParameters.java
@@ -6,21 +6,32 @@ import com.fasterxml.jackson.annotation.JsonSetter;
 import nl.inl.blacklab.search.indexmetadata.MatchSensitivity;
 
 public class BLSConfigParameters {
+    /** What pattern language to use? */
     String patternLanguage = "corpusql";
-    
+
+    /** What document filter language to use? */
     String filterLanguage = "luceneql";
-    
+
+    /** Should we default to case-/accent-sensitive search or not? */
     MatchSensitivity defaultSearchSensitivity;
 
+    /** After how many hits should we stop processing them? */
     DefaultMax processHits = DefaultMax.get(5000000, 5000000);
-    
+
+    /** After how many hits should we stop counting them? */
     DefaultMax countHits = DefaultMax.get(10000000, 10000000);
-    
+
+    /** How many results should we return per page by default? */
     DefaultMax pageSize = DefaultMax.get(50, 3000);
-    
+
+    /** How many words of context should we return before and after matches? */
     DefaultMax contextSize = DefaultMax.get(5, 200);
 
+    /** Should we return group contents with grouped results? */
     private boolean writeHitsAndDocsInGroupedHits = false;
+
+    /** If a group of length 0 is captured (same start and end position), should we omit it instead? */
+    private boolean omitEmptyCaptures = false;
 
 
     @JsonGetter("defaultSearchSensitivity")
@@ -95,5 +106,14 @@ public class BLSConfigParameters {
 
     public void setWriteHitsAndDocsInGroupedHits(boolean writeHitsAndDocsInGroupedHits) {
         this.writeHitsAndDocsInGroupedHits = writeHitsAndDocsInGroupedHits;
+    }
+
+    public boolean isOmitEmptyCaptures() {
+        return omitEmptyCaptures;
+    }
+
+    @SuppressWarnings("unused")
+    public void setOmitEmptyCaptures(boolean omitEmptyCaptures) {
+        this.omitEmptyCaptures = omitEmptyCaptures;
     }
 }

--- a/server/src/main/java/nl/inl/blacklab/server/requesthandlers/RequestHandler.java
+++ b/server/src/main/java/nl/inl/blacklab/server/requesthandlers/RequestHandler.java
@@ -1001,7 +1001,7 @@ public abstract class RequestHandler {
             ds.entry("end", hit.end());
 
             if (hits.hasCapturedGroups()) {
-                Map<String, Span> capturedGroups = hits.capturedGroups().getMap(hit);
+                Map<String, Span> capturedGroups = hits.capturedGroups().getMap(hit, searchParam.omitEmptyCapture());
                 if (capturedGroups != null) {
                     ds.startEntry("captureGroups").startList();
 

--- a/server/src/main/java/nl/inl/blacklab/server/requesthandlers/SearchParameters.java
+++ b/server/src/main/java/nl/inl/blacklab/server/requesthandlers/SearchParameters.java
@@ -104,6 +104,8 @@ public class SearchParameters {
         defaultParameterValues.put("subprops", "");
         defaultParameterValues.put("csvsummary", "no");
         defaultParameterValues.put("csvsepline", "no");
+        defaultParameterValues.put("includegroupcontents", "no");
+        defaultParameterValues.put("omitemptycaptures", "no");
     }
 
     private static String getDefault(String paramName) {
@@ -189,7 +191,10 @@ public class SearchParameters {
             "csvsepline", // include separator declaration for Excel? [no]
 
             // Deprecated parameters
-            "property" // now called "annotation"
+            "property", // now called "annotation",
+
+            "includegroupcontents", // include hits with the group response? (false)
+            "omitemptycaptures"  // omit capture groups of length 0? (false)
 
     );
 
@@ -416,6 +421,13 @@ public class SearchParameters {
             return getBoolean("includegroupcontents");
         }
         return searchManager.config().getParameters().isWriteHitsAndDocsInGroupedHits();
+    }
+
+    public boolean omitEmptyCapture() {
+        if (containsKey("omitemptycaptures")) {
+            return getBoolean("omitemptycaptures");
+        }
+        return searchManager.config().getParameters().isOmitEmptyCaptures();
     }
 
     private List<DocProperty> getFacets() {


### PR DESCRIPTION
Backport  of `https://github.com/INL/BlackLab/commit/998f86fc3489c0a35e7c6c2325327bc2246b16d4`

>Set BLS configuration setting parameters.omitEmptyCaptures or URL parameter
omitemptycaptures to true to ensure that captures of length 0 will be omitted.
Such captures can occur when the clause being captured is optional, e.g. `A:[]?`.
It will not happen when the capture itself is optional, e.g. `(A:[])?`.