### PR TITLE
Add userIndexMaxTokenCount setting (thanks @eginez).

### DIFF
--- a/engine/src/main/java/nl/inl/blacklab/config/BLConfigIndexing.java
+++ b/engine/src/main/java/nl/inl/blacklab/config/BLConfigIndexing.java
@@ -3,6 +3,10 @@ package nl.inl.blacklab.config;
 import nl.inl.blacklab.search.indexmetadata.MetadataFieldImpl;
 
 public class BLConfigIndexing {
+
+    /** Max tokens for a private user index, default 100M **/
+    private long userIndexMaxTokenCount = 100_000_000;
+
     boolean downloadAllowed = false;
     
     String downloadCacheDir = null;
@@ -80,4 +84,12 @@ public class BLConfigIndexing {
         this.maxNumberOfIndicesPerUser = maxNumberOfIndicesPerUser;
     }
 
+    @SuppressWarnings("unused")
+    public void setUserIndexMaxTokenCount(int maxTokenCount) {
+        this.userIndexMaxTokenCount = maxTokenCount;
+    }
+
+    public long getUserIndexMaxTokenCount() {
+        return this.userIndexMaxTokenCount;
+    }
 }

--- a/server/src/main/java/nl/inl/blacklab/server/requesthandlers/RequestHandlerAddToIndex.java
+++ b/server/src/main/java/nl/inl/blacklab/server/requesthandlers/RequestHandlerAddToIndex.java
@@ -18,6 +18,7 @@ import org.apache.commons.io.IOUtils;
 import nl.inl.blacklab.exceptions.IndexTooOld;
 import nl.inl.blacklab.index.IndexListenerReportConsole;
 import nl.inl.blacklab.index.Indexer;
+import nl.inl.blacklab.search.BlackLab;
 import nl.inl.blacklab.search.indexmetadata.IndexMetadata;
 import nl.inl.blacklab.server.BlackLabServer;
 import nl.inl.blacklab.server.datastream.DataStream;
@@ -33,9 +34,6 @@ import nl.inl.blacklab.server.util.FileUploadHandler;
  * Display the contents of the cache.
  */
 public class RequestHandlerAddToIndex extends RequestHandler {
-    // TODO make configurable?
-    public static final int MAX_TOKEN_COUNT = 100_000_000;
-
     String indexError = null;
 
     public RequestHandlerAddToIndex(BlackLabServer servlet,
@@ -87,9 +85,10 @@ public class RequestHandlerAddToIndex extends RequestHandler {
         if (!index.userMayAddData(user))
             throw new NotAuthorized("You can only add new data to your own private indices.");
 
-        if (indexMetadata.tokenCount() > MAX_TOKEN_COUNT) {
-            throw new NotAuthorized("Sorry, this index is already larger than the maximum of " + MAX_TOKEN_COUNT
-                    + " tokens. Cannot add any more data to it.");
+        long maxTokenCount = BlackLab.config().getIndexing().getUserIndexMaxTokenCount();
+        if (indexMetadata.tokenCount() > maxTokenCount) {
+            throw new NotAuthorized("Sorry, this index is already larger than the maximum of " + maxTokenCount
+                    + " tokens allowed in a user index. Cannot add any more data to it.");
         }
 
         Indexer indexer = index.getIndexer();


### PR DESCRIPTION
Cherry-pick of:https://github.com/INL/BlackLab/commit/259beff5f49ee528b7262b4ce35b9e0f855acd0d

indexing.userIndexMaxTokenCount sets the maximum size for a private user corpus (default 100M tokens).

Squashed commit of the following:

commit 7f5f9f1332c5dbb28ad4267d997613ba87cc62c0
Author: Jan Niestadt <jan.niestadt@ivdnt.org>
Date:   Tue Oct 4 11:47:39 2022 +0200

    Comment, text tweaks.

commit 5d58ed006bbc9f7b64ca455fc782f9fcfb906dd2
Author: Esteban Ginez <175813+eginez@users.noreply.github.com>
Date:   Thu Sep 29 12:28:31 2022 -0700

    comment

commit 5c2b582c68a7a2490ca20e4483a0b29a266e8e06
Author: Esteban Ginez <175813+eginez@users.noreply.github.com>
Date:   Thu Sep 29 12:27:24 2022 -0700

    delete comment

commit 40f897a17623c058b627d47c36e1c1f5430d005d
Author: Esteban Ginez <175813+eginez@users.noreply.github.com>
Date:   Thu Sep 29 12:22:28 2022 -0700

    adds max tokens for private index setting