### PR TITLE
Limits time available for search

### DIFF
--- a/server/src/main/java/nl/inl/blacklab/server/requesthandlers/RequestHandlerHits.java
+++ b/server/src/main/java/nl/inl/blacklab/server/requesthandlers/RequestHandlerHits.java
@@ -152,8 +152,12 @@ public class RequestHandlerHits extends RequestHandler {
 
 
         WindowSettings windowSettings = searchParam.getWindowSettings();
-        if (!hits.hitsStats().processedAtLeast(windowSettings.first()))
+        int soFar = hits.hitsStats().processedSoFar();
+        if (!hits.hitsStats().processedAtLeast(windowSettings.first())) {
+            logger.info("Docs so far: {}", soFar);
+            logger.info("Window requested: {}", windowSettings.first());
             throw new BadRequest("HIT_NUMBER_OUT_OF_RANGE", "Non-existent hit number specified.");
+        }
 
         SearchCacheEntry<Hits> cacheEntryWindow = null;
         Hits window;

--- a/server/src/main/java/nl/inl/blacklab/server/requesthandlers/RequestHandlerHits.java
+++ b/server/src/main/java/nl/inl/blacklab/server/requesthandlers/RequestHandlerHits.java
@@ -152,12 +152,8 @@ public class RequestHandlerHits extends RequestHandler {
 
 
         WindowSettings windowSettings = searchParam.getWindowSettings();
-        int soFar = hits.hitsStats().processedSoFar();
-        if (!hits.hitsStats().processedAtLeast(windowSettings.first())) {
-            logger.info("Docs so far: {}", soFar);
-            logger.info("Window requested: {}", windowSettings.first());
+        if (!hits.hitsStats().processedAtLeast(windowSettings.first()))
             throw new BadRequest("HIT_NUMBER_OUT_OF_RANGE", "Non-existent hit number specified.");
-        }
 
         SearchCacheEntry<Hits> cacheEntryWindow = null;
         Hits window;

--- a/server/src/main/java/nl/inl/blacklab/server/search/ResultsCache.java
+++ b/server/src/main/java/nl/inl/blacklab/server/search/ResultsCache.java
@@ -145,7 +145,7 @@ public class ResultsCache implements SearchCache {
 
     public ResultsCache(BLSConfig config, ExecutorService threadPool)  {
         this.threadPool = threadPool;
-        int maxSearchTime = config.getCache().getMaxSearchTimeSec();
+        int maxSearchTimeSec = config.getCache().getMaxSearchTimeSec();
 
         CacheLoader<SearchInfoWrapper, SearchResult> cacheLoader = new CacheLoader<SearchInfoWrapper, SearchResult>() {
             @Override
@@ -161,8 +161,8 @@ public class ResultsCache implements SearchCache {
                 }));
                 try {
                     CacheEntryWithResults<? extends SearchResult> searchResult;
-                    if (maxSearchTime > 0) {
-                         searchResult = job.get(maxSearchTime * 1000, TimeUnit.MILLISECONDS);
+                    if (maxSearchTimeSec > 0) {
+                         searchResult = job.get((long)maxSearchTimeSec * 1000, TimeUnit.MILLISECONDS);
                     } else {
                          searchResult = job.get();
                     }
@@ -180,7 +180,7 @@ public class ResultsCache implements SearchCache {
 
         int maxSize = config.getCache().getMaxNumberOfJobs();
         logger.info("Creating cache with maxSize: {}", maxSize);
-        logger.info("Creating cache with max search time: {} sec", maxSearchTime);
+        logger.info("Creating cache with max search time: {} sec", maxSearchTimeSec);
         searchCache = Caffeine.newBuilder()
             .recordStats()
             .maximumSize(maxSize)


### PR DESCRIPTION
Allows for searches to timeout after a configured maximum time. Adds  a metric to track timed out jobs.

This also moves the searches to blacklab's search executor service as opposed to the default pool.