### PR TITLE
Chun/blacklab security upgrade 2024-09

### DIFF
--- a/contrib/legacy-docindexers/src/main/java/nl/inl/blacklab/indexers/MetadataFetcherCgnImdi.java
+++ b/contrib/legacy-docindexers/src/main/java/nl/inl/blacklab/indexers/MetadataFetcherCgnImdi.java
@@ -21,7 +21,8 @@ import javax.xml.parsers.SAXParserFactory;
 import org.apache.commons.io.input.TeeInputStream;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field.Store;
-import org.apache.lucene.document.IntField;
+import org.apache.lucene.document.IntPoint;
+import org.apache.lucene.document.StoredField;
 import org.xml.sax.Attributes;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
@@ -144,7 +145,8 @@ public class MetadataFetcherCgnImdi extends MetadataFetcher {
             // Lucene document
             ContentStore cs = docIndexer.getDocWriter().contentStore("metadata");
             int id = cs.store(cmdiBuffer.toString(Indexer.DEFAULT_INPUT_ENCODING.name()));
-            luceneDoc.add(new IntField("metadataCid", id, Store.YES));
+            luceneDoc.add(new IntPoint("metaDataCid", id));
+            luceneDoc.add(new StoredField("metadataCid", id));
 
             if (metadataZipFile == null)
                 is.close();

--- a/contrib/legacy-docindexers/src/main/java/nl/inl/blacklab/indexers/MetadataFetcherSonarCmdi.java
+++ b/contrib/legacy-docindexers/src/main/java/nl/inl/blacklab/indexers/MetadataFetcherSonarCmdi.java
@@ -21,7 +21,8 @@ import javax.xml.parsers.SAXParserFactory;
 import org.apache.commons.io.input.TeeInputStream;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field.Store;
-import org.apache.lucene.document.IntField;
+import org.apache.lucene.document.IntPoint;
+import org.apache.lucene.document.StoredField;
 import org.xml.sax.Attributes;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
@@ -153,7 +154,8 @@ public class MetadataFetcherSonarCmdi extends MetadataFetcher {
             // Store metadata XML in content store and corresponding id in Lucene document
             ContentStore cs = docIndexer.getDocWriter().contentStore("metadata");
             int id = cs.store(cmdiBuffer.toString(Indexer.DEFAULT_INPUT_ENCODING.name()));
-            luceneDoc.add(new IntField("metadataCid", id, Store.YES));
+            luceneDoc.add(new IntPoint("metadataCid", id));
+            luceneDoc.add(new StoredField("metadataCid", id));
 
             if (metadataZipFile == null)
                 is.close();

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -84,6 +84,13 @@
             <version>${blacklab.luceneVersion}</version>
         </dependency>
 
+        <!-- Solr, for a Lucene package that was moved there at 7.0 -->
+        <dependency>
+            <groupId>org.apache.solr</groupId>
+            <artifactId>solr-core</artifactId>
+            <version>9.6.1</version>
+        </dependency>
+
         <!-- Specific more efficient collection types -->
         <dependency>
             <groupId>org.eclipse.collections</groupId>

--- a/engine/src/main/java/nl/inl/blacklab/forwardindex/FiidLookup.java
+++ b/engine/src/main/java/nl/inl/blacklab/forwardindex/FiidLookup.java
@@ -51,7 +51,7 @@ public class FiidLookup {
                 if (numericDocValues == null) {
                     // Use UninvertingReader to simulate DocValues (slower)
                     Map<String, UninvertingReader.Type> fields = new TreeMap<>();
-                    fields.put(fiidFieldName, UninvertingReader.Type.INTEGER);
+                    fields.put(fiidFieldName, UninvertingReader.Type.INTEGER_POINT);
                     @SuppressWarnings("resource")
                     UninvertingReader uninv = new UninvertingReader(r, fields);
                     numericDocValues = uninv.getNumericDocValues(fiidFieldName);

--- a/engine/src/main/java/nl/inl/blacklab/forwardindex/FiidLookup.java
+++ b/engine/src/main/java/nl/inl/blacklab/forwardindex/FiidLookup.java
@@ -11,7 +11,7 @@ import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.NumericDocValues;
-import org.apache.lucene.uninverting.UninvertingReader;
+import org.apache.solr.uninverting.UninvertingReader;
 
 import nl.inl.blacklab.exceptions.BlackLabRuntimeException;
 import nl.inl.blacklab.search.indexmetadata.Annotation;

--- a/engine/src/main/java/nl/inl/blacklab/forwardindex/FiidLookup.java
+++ b/engine/src/main/java/nl/inl/blacklab/forwardindex/FiidLookup.java
@@ -2,6 +2,7 @@ package nl.inl.blacklab.forwardindex;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -38,7 +39,10 @@ public class FiidLookup {
     private String fiidFieldName;
 
     /** The DocValues per segment (keyed by docBase) */
-    private Map<Integer, NumericDocValues> cachedFiids;
+    private Map<Integer, NumericDocValues> cachedFiids = new TreeMap<>();
+
+    /** Any cached mappings from Lucene docId to forward index id (fiid) or null if not using cache */
+    private final Map<Integer, Long> docIdToFiidCache = new HashMap<>();
 
     public FiidLookup(IndexReader reader, Annotation annotation) {
         this.fiidFieldName = annotation.forwardIndexIdField();
@@ -75,36 +79,41 @@ public class FiidLookup {
     }
 
     public int get(int docId) {
-        if (cachedFiids != null) {
-            // Find the fiid in the correct segment
-            Entry<Integer, NumericDocValues> prev = null;
-            for (Entry<Integer, NumericDocValues> e : cachedFiids.entrySet()) {
-                Integer docBase = e.getKey();
-                if (docBase > docId) {
-                    // Previous segment (the highest docBase lower than docId) is the right one
-                    Integer prevDocBase = prev.getKey();
-                    NumericDocValues prevDocValues = prev.getValue();
-                    synchronized (prevDocValues) {
-                        return (int) prevDocValues.get(docId - prevDocBase);
-                    }
-                }
-                prev = e;
-            }
-            // Last segment is the right one
-            Integer prevDocBase = prev.getKey();
-            NumericDocValues prevDocValues = prev.getValue();
-            synchronized (prevDocValues) {
-                return (int) prevDocValues.get(docId - prevDocBase);
-            }
+        // Is the fiid in the cache (if we have one)?
+        Long fiid = docIdToFiidCache.get(docId);
+        if (fiid != null)
+        {
+            // Yes; return value from the cache.
+            return (int)(long)fiid;
         }
+
+        // Find the fiid in the correct segment
+        Entry<Integer, NumericDocValues> prev = null;
+        for (Entry<Integer, NumericDocValues> e : cachedFiids.entrySet()) {
+            Integer docBase = e.getKey();
+            if (docBase > docId) {
+                // Previous segment (the highest docBase lower than docId) is the right one
+                Integer prevDocBase = prev.getKey();
+                NumericDocValues prevDocValues = prev.getValue();
+                return getFiidFromDocValues(prevDocBase, prevDocValues, docId);
+            }
+            prev = e;
+        }
+        
+        // Last segment is the right one
+        assert prev != null;
+        Integer prevDocBase = prev.getKey();
+        NumericDocValues prevDocValues = prev.getValue();
+        return getFiidFromDocValues(prevDocBase, prevDocValues, docId);
 
         // Not cached; find fiid by reading stored value from Document now
-        try {
-            return (int)Long.parseLong(reader.document(docId).get(fiidFieldName));
-        } catch (IOException e) {
-            throw BlackLabRuntimeException.wrap(e);
-        }
-
+        // INL/Blacklab removed this, seems convinced that this would never happen, but I'm not sure if that's true for us
+        // 
+        // try {
+        //     return (int)Long.parseLong(reader.document(docId).get(fiidFieldName));
+        // } catch (IOException e) {
+        //     throw BlackLabRuntimeException.wrap(e);
+        // }
     }
 
     public boolean hasFiids(int numToCheck) {
@@ -128,5 +137,38 @@ public class FiidLookup {
             fiidLookups.add(annotation == null ? null : new FiidLookup(reader, annotation));
         }
         return fiidLookups;
+    }
+
+    /**
+     * Get the requested forward index id from the DocValues object.
+     *
+     * Optionally caches any skipped values for later.
+     *
+     * @param docBase doc base for this segement
+     * @param docValues doc values for this segment
+     * @param docId document to get the fiid for
+     * @return forward index id
+     */
+    private int getFiidFromDocValues(int docBase, NumericDocValues docValues, int docId) {
+        try {
+            if (docIdToFiidCache == null) {
+                // Not caching (because we know our docIds are always increasing)
+                docValues.advanceExact(docId - docBase);
+                return (int) docValues.longValue();
+            } else {
+                // Caching; gather all fiid values in our cache until we find the requested one.
+                do {
+                    docValues.nextDoc();
+                    docIdToFiidCache.put(docValues.docID() + docBase, docValues.longValue());
+                    if (docValues.docID() == docId - docBase) {
+                        // Requested docvalue found.
+                        return (int) docValues.longValue();
+                    }
+                } while (docValues.docID() <= docId - docBase);
+                throw new BlackLabRuntimeException("not found in docvalues");
+            }
+        } catch (IOException e1) {
+            throw BlackLabRuntimeException.wrap(e1);
+        }
     }
 }

--- a/engine/src/main/java/nl/inl/blacklab/forwardindex/FiidLookup.java
+++ b/engine/src/main/java/nl/inl/blacklab/forwardindex/FiidLookup.java
@@ -50,10 +50,9 @@ public class FiidLookup {
                 NumericDocValues numericDocValues = r.getNumericDocValues(fiidFieldName);
                 if (numericDocValues == null) {
                     // Use UninvertingReader to simulate DocValues (slower)
-                    Map<String, UninvertingReader.Type> fields = new TreeMap<>();
-                    fields.put(fiidFieldName, UninvertingReader.Type.INTEGER_POINT);
                     @SuppressWarnings("resource")
-                    UninvertingReader uninv = new UninvertingReader(r, fields);
+                    LeafReader uninv = UninvertingReader.wrap(r, (String s) -> UninvertingReader.Type.INTEGER_POINT);
+                    // UninvertingReader uninv = new UninvertingReader(r, fields);
                     numericDocValues = uninv.getNumericDocValues(fiidFieldName);
                 }
                 if (numericDocValues != null) {

--- a/engine/src/main/java/nl/inl/blacklab/forwardindex/ForwardIndexImplSeparate.java
+++ b/engine/src/main/java/nl/inl/blacklab/forwardindex/ForwardIndexImplSeparate.java
@@ -15,7 +15,8 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field.Store;
-import org.apache.lucene.document.IntField;
+import org.apache.lucene.document.IntPoint;
+import org.apache.lucene.document.StoredField;
 import org.apache.lucene.document.NumericDocValuesField;
 
 import nl.inl.blacklab.search.BlackLabIndex;
@@ -130,7 +131,8 @@ public class ForwardIndexImplSeparate implements ForwardIndex {
             List<Integer> posIncrThisAnnot = posIncr.get(annotation);
             int fiid = afi.addDocument(e.getValue(), posIncrThisAnnot);
             String fieldName = annotation.forwardIndexIdField();
-            document.add(new IntField(fieldName, fiid, Store.YES));
+            document.add(new IntPoint(fieldName, fiid));
+            document.add(new StoredField(fieldName, fiid));
             document.add(new NumericDocValuesField(fieldName, fiid)); // for fast retrieval (FiidLookup)
         }
     }

--- a/engine/src/main/java/nl/inl/blacklab/index/DocIndexer.java
+++ b/engine/src/main/java/nl/inl/blacklab/index/DocIndexer.java
@@ -41,7 +41,8 @@ import org.apache.logging.log4j.Logger;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.Field.Store;
-import org.apache.lucene.document.IntField;
+import org.apache.lucene.document.IntPoint;
+import org.apache.lucene.document.StoredField;
 import org.apache.lucene.document.NumericDocValuesField;
 import org.apache.lucene.document.SortedSetDocValuesField;
 import org.apache.lucene.util.BytesRef;
@@ -524,8 +525,8 @@ public abstract class DocIndexer implements AutoCloseable {
                     // descriptive text like "around 1900". OK to ignore.
                     n = 0;
                 }
-                IntField nf = new IntField(numFieldName, n, Store.YES);
-                currentLuceneDoc.add(nf);
+                currentLuceneDoc.add(new IntPoint(numFieldName, n));
+                currentLuceneDoc.add(new StoredField(numFieldName, n));
                 if (firstValue)
                     currentLuceneDoc.add(new NumericDocValuesField(numFieldName, n)); // docvalues for efficient sorting/grouping
                 else {

--- a/engine/src/main/java/nl/inl/blacklab/index/DocIndexerPlainTextBasic.java
+++ b/engine/src/main/java/nl/inl/blacklab/index/DocIndexerPlainTextBasic.java
@@ -22,7 +22,8 @@ import java.lang.reflect.Constructor;
 
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field.Store;
-import org.apache.lucene.document.IntField;
+import org.apache.lucene.document.IntPoint;
+import org.apache.lucene.document.StoredField;
 
 import nl.inl.blacklab.exceptions.BlackLabRuntimeException;
 import nl.inl.blacklab.exceptions.MalformedInputFile;
@@ -207,7 +208,9 @@ public class DocIndexerPlainTextBasic extends DocIndexerAbstract {
             // positions for the closing token still make (some) sense)
             int contentId = storeCapturedContent();
             currentLuceneDoc
-                    .add(new IntField(AnnotatedFieldNameUtil.contentIdField(contentsField.name()), contentId, Store.YES));
+                    .add(new IntPoint(AnnotatedFieldNameUtil.contentIdField(contentsField.name()), contentId));
+            currentLuceneDoc
+                    .add(new StoredField(AnnotatedFieldNameUtil.contentIdField(contentsField.name()), contentId));
 
             // Store the different properties of the annotated contents field that
             // were gathered in lists while parsing.

--- a/engine/src/main/java/nl/inl/blacklab/index/DocIndexerXmlHandlers.java
+++ b/engine/src/main/java/nl/inl/blacklab/index/DocIndexerXmlHandlers.java
@@ -31,7 +31,8 @@ import javax.xml.parsers.SAXParserFactory;
 import org.apache.commons.text.StringEscapeUtils;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field.Store;
-import org.apache.lucene.document.IntField;
+import org.apache.lucene.document.IntPoint;
+import org.apache.lucene.document.StoredField;
 import org.apache.lucene.util.BytesRef;
 import org.xml.sax.Attributes;
 import org.xml.sax.InputSource;
@@ -135,9 +136,10 @@ public abstract class DocIndexerXmlHandlers extends DocIndexerAbstract {
             // (Note that we do this after adding the "extra closing token", so the character
             // positions for the closing token still make (some) sense)
             int contentId = storeCapturedContent();
-            currentLuceneDoc.add(new IntField(AnnotatedFieldNameUtil
-                    .contentIdField(contentsField.name()), contentId,
-                    Store.YES));
+            currentLuceneDoc.add(new IntPoint(AnnotatedFieldNameUtil
+                    .contentIdField(contentsField.name()), contentId));
+            currentLuceneDoc.add(new StoredField(AnnotatedFieldNameUtil
+                    .contentIdField(contentsField.name()), contentId));
 
             // Store the different properties of the annotated contents field that
             // were gathered in

--- a/engine/src/main/java/nl/inl/blacklab/index/annotated/AnnotatedFieldWriter.java
+++ b/engine/src/main/java/nl/inl/blacklab/index/annotated/AnnotatedFieldWriter.java
@@ -25,7 +25,8 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
-import org.apache.lucene.document.IntField;
+import org.apache.lucene.document.IntPoint;
+import org.apache.lucene.document.StoredField;
 import org.apache.lucene.document.NumericDocValuesField;
 import org.eclipse.collections.impl.list.mutable.primitive.IntArrayList;
 
@@ -146,7 +147,8 @@ public class AnnotatedFieldWriter {
         //  that doesn't contain a word but may contain trailing punctuation)
         String lengthTokensFieldName = AnnotatedFieldNameUtil.lengthTokensField(fieldName);
         int lengthTokensValue = numberOfTokens();
-        doc.add(new IntField(lengthTokensFieldName, lengthTokensValue, Field.Store.YES));
+        doc.add(new IntPoint(lengthTokensFieldName, lengthTokensValue));
+        doc.add(new StoredField(lengthTokensFieldName, lengthTokensValue));
         doc.add(new NumericDocValuesField(lengthTokensFieldName, lengthTokensValue)); // docvalues for fast retrieval
     }
 

--- a/engine/src/main/java/nl/inl/blacklab/indexers/config/DocIndexerBase.java
+++ b/engine/src/main/java/nl/inl/blacklab/indexers/config/DocIndexerBase.java
@@ -21,7 +21,8 @@ import java.util.Set;
 import org.apache.commons.io.IOUtils;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field.Store;
-import org.apache.lucene.document.IntField;
+import org.apache.lucene.document.IntPoint;
+import org.apache.lucene.document.StoredField;
 import org.apache.lucene.util.BytesRef;
 
 import nl.inl.blacklab.contentstore.ContentStore;
@@ -488,7 +489,8 @@ public abstract class DocIndexerBase extends DocIndexer {
             ContentStore contentStore = docWriter.contentStore(contentStoreName);
             contentId = contentStore.store(document);
         }
-        currentLuceneDoc.add(new IntField(contentIdFieldName, contentId, Store.YES));
+        currentLuceneDoc.add(new IntPoint(contentIdFieldName, contentId));
+        currentLuceneDoc.add(new StoredField(contentIdFieldName, contentId));
     }
 
     protected void storeWholeDocument(byte[] content, int offset, int length, Charset cs) {
@@ -515,7 +517,8 @@ public abstract class DocIndexerBase extends DocIndexer {
             ContentStore contentStore = docWriter.contentStore(contentStoreName);
             contentId = contentStore.store(content, offset, length, cs);
         }
-        currentLuceneDoc.add(new IntField(contentIdFieldName, contentId, Store.YES));
+        currentLuceneDoc.add(new IntPoint(contentIdFieldName, contentId));
+        currentLuceneDoc.add(new StoredField(contentIdFieldName, contentId));
     }
 
     /**

--- a/engine/src/main/java/nl/inl/blacklab/resultproperty/DocPropertyAnnotatedFieldLength.java
+++ b/engine/src/main/java/nl/inl/blacklab/resultproperty/DocPropertyAnnotatedFieldLength.java
@@ -74,10 +74,8 @@ public class DocPropertyAnnotatedFieldLength extends DocProperty {
                 NumericDocValues numericDocValues = r.getNumericDocValues(fieldName);
                 if (numericDocValues == null) {
                     // Use UninvertingReader to simulate DocValues (slower)
-                    Map<String, UninvertingReader.Type> fields = new TreeMap<>();
-                    fields.put(fieldName, UninvertingReader.Type.INTEGER_POINT);
                     @SuppressWarnings("resource")
-                    UninvertingReader uninv = new UninvertingReader(r, fields);
+                    LeafReader uninv = UninvertingReader.wrap(r, (String s) -> UninvertingReader.Type.INTEGER_POINT);
                     numericDocValues = uninv.getNumericDocValues(fieldName);
                 }
                 if (numericDocValues != null) {

--- a/engine/src/main/java/nl/inl/blacklab/resultproperty/DocPropertyAnnotatedFieldLength.java
+++ b/engine/src/main/java/nl/inl/blacklab/resultproperty/DocPropertyAnnotatedFieldLength.java
@@ -75,7 +75,7 @@ public class DocPropertyAnnotatedFieldLength extends DocProperty {
                 if (numericDocValues == null) {
                     // Use UninvertingReader to simulate DocValues (slower)
                     Map<String, UninvertingReader.Type> fields = new TreeMap<>();
-                    fields.put(fieldName, UninvertingReader.Type.INTEGER);
+                    fields.put(fieldName, UninvertingReader.Type.INTEGER_POINT);
                     @SuppressWarnings("resource")
                     UninvertingReader uninv = new UninvertingReader(r, fields);
                     numericDocValues = uninv.getNumericDocValues(fieldName);

--- a/engine/src/main/java/nl/inl/blacklab/resultproperty/DocPropertyAnnotatedFieldLength.java
+++ b/engine/src/main/java/nl/inl/blacklab/resultproperty/DocPropertyAnnotatedFieldLength.java
@@ -24,7 +24,7 @@ import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.NumericDocValues;
 import org.apache.lucene.search.Query;
-import org.apache.lucene.uninverting.UninvertingReader;
+import org.apache.solr.uninverting.UninvertingReader;
 
 import nl.inl.blacklab.exceptions.BlackLabRuntimeException;
 import nl.inl.blacklab.search.BlackLabIndex;

--- a/engine/src/main/java/nl/inl/blacklab/resultproperty/DocPropertyAnnotatedFieldLength.java
+++ b/engine/src/main/java/nl/inl/blacklab/resultproperty/DocPropertyAnnotatedFieldLength.java
@@ -30,6 +30,8 @@ import nl.inl.blacklab.exceptions.BlackLabRuntimeException;
 import nl.inl.blacklab.search.BlackLabIndex;
 import nl.inl.blacklab.search.indexmetadata.AnnotatedFieldNameUtil;
 import nl.inl.blacklab.search.results.DocResult;
+import nl.inl.util.DocValuesUtil;
+import nl.inl.util.NumericDocValuesCacher;
 
 /**
  * Retrieves the length of an annotated field (i.e. the main "contents" field) in
@@ -52,7 +54,7 @@ public class DocPropertyAnnotatedFieldLength extends DocProperty {
     private String friendlyName;
 
     /** The DocValues per segment (keyed by docBase), or null if we don't have docValues */
-    private Map<Integer, NumericDocValues> docValues = null;
+    private Map<Integer, NumericDocValuesCacher> docValues = null;
     
     private BlackLabIndex index;
 
@@ -71,7 +73,7 @@ public class DocPropertyAnnotatedFieldLength extends DocProperty {
         try {
             for (LeafReaderContext rc : index.reader().leaves()) {
                 LeafReader r = rc.reader();
-                NumericDocValues numericDocValues = r.getNumericDocValues(fieldName);
+                NumericDocValues numericDocValues = r.getNumericDocValues(this.fieldName);
                 if (numericDocValues == null) {
                     // Use UninvertingReader to simulate DocValues (slower)
                     @SuppressWarnings("resource")
@@ -79,7 +81,7 @@ public class DocPropertyAnnotatedFieldLength extends DocProperty {
                     numericDocValues = uninv.getNumericDocValues(fieldName);
                 }
                 if (numericDocValues != null) {
-                    docValues.put(rc.docBase, numericDocValues);
+                    docValues.put(rc.docBase, DocValuesUtil.cacher(numericDocValues));
                 }
             }
             if (docValues.isEmpty()) {
@@ -98,25 +100,21 @@ public class DocPropertyAnnotatedFieldLength extends DocProperty {
     public long get(int docId) {
         if (docValues != null) {
             // Find the fiid in the correct segment
-            Entry<Integer, NumericDocValues> prev = null;
-            for (Entry<Integer, NumericDocValues> e : docValues.entrySet()) {
+            Entry<Integer, NumericDocValuesCacher> prev = null;
+            for (Entry<Integer, NumericDocValuesCacher> e : docValues.entrySet()) {
                 Integer docBase = e.getKey();
                 if (docBase > docId) {
                     // Previous segment (the highest docBase lower than docId) is the right one
                     Integer prevDocBase = prev.getKey();
-                    NumericDocValues prevDocValues = prev.getValue();
-                    synchronized (prevDocValues) {
-                        return prevDocValues.get(docId - prevDocBase) - BlackLabIndex.IGNORE_EXTRA_CLOSING_TOKEN;
-                    }
+                    NumericDocValuesCacher prevDocValues = prev.getValue();
+                    return prevDocValues.get(docId - prevDocBase) - BlackLabIndex.IGNORE_EXTRA_CLOSING_TOKEN;
                 }
                 prev = e;
             }
             // Last segment is the right one
             Integer prevDocBase = prev.getKey();
-            NumericDocValues prevDocValues = prev.getValue();
-            synchronized (prevDocValues) {
-                return prevDocValues.get(docId - prevDocBase) - BlackLabIndex.IGNORE_EXTRA_CLOSING_TOKEN;
-            }
+            NumericDocValuesCacher prevDocValues = prev.getValue();
+            return prevDocValues.get(docId - prevDocBase) - BlackLabIndex.IGNORE_EXTRA_CLOSING_TOKEN;
         }
         
         // Not cached; find fiid by reading stored value from Document now

--- a/engine/src/main/java/nl/inl/blacklab/resultproperty/DocPropertyStoredField.java
+++ b/engine/src/main/java/nl/inl/blacklab/resultproperty/DocPropertyStoredField.java
@@ -16,7 +16,6 @@
 package nl.inl.blacklab.resultproperty;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -35,7 +34,6 @@ import org.apache.lucene.index.Term;
 import org.apache.lucene.queryparser.classic.ParseException;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
-import org.apache.lucene.util.BytesRef;
 
 import nl.inl.blacklab.exceptions.BlackLabRuntimeException;
 import nl.inl.blacklab.search.BlackLabIndex;
@@ -43,7 +41,11 @@ import nl.inl.blacklab.search.BlackLabIndexImpl;
 import nl.inl.blacklab.search.indexmetadata.FieldType;
 import nl.inl.blacklab.search.indexmetadata.MetadataField;
 import nl.inl.blacklab.search.results.DocResult;
+import nl.inl.util.DocValuesUtil;
 import nl.inl.util.LuceneUtil;
+import nl.inl.util.NumericDocValuesCacher;
+import nl.inl.util.SortedDocValuesCacher;
+import nl.inl.util.SortedSetDocValuesCacher;
 import nl.inl.util.StringUtil;
 
 /**
@@ -65,9 +67,9 @@ public class DocPropertyStoredField extends DocProperty {
     private String friendlyName;
 
     /** The DocValues per segment (keyed by docBase), or null if we don't have docValues. New indexes all have SortedSetDocValues, but some very old indexes may still contain regular SortedDocValues! */
-    private Map<Integer, Pair<SortedDocValues, SortedSetDocValues>> docValues = null;
+    private Map<Integer, Pair<SortedDocValuesCacher, SortedSetDocValuesCacher>> docValues = null;
     /** Null unless the field is numeric. */
-    private Map<Integer, NumericDocValues> numericDocValues = null;
+    private Map<Integer, NumericDocValuesCacher> numericDocValues = null;
 
     /** Our index */
     private BlackLabIndex index;
@@ -96,7 +98,7 @@ public class DocPropertyStoredField extends DocProperty {
                         LeafReader r = rc.reader();
                         // NOTE: can be null! This is valid and indicates the documents in this segment does not contain any values for this field.
                         NumericDocValues values = r.getNumericDocValues(fieldName);
-                        numericDocValues.put(rc.docBase, values);
+                        numericDocValues.put(rc.docBase, DocValuesUtil.cacher(values));
                     }
                 } else { // regular string doc values.
                     docValues = new TreeMap<>();
@@ -106,7 +108,7 @@ public class DocPropertyStoredField extends DocProperty {
                         SortedSetDocValues sortedSetDocValues = r.getSortedSetDocValues(fieldName);
                         SortedDocValues sortedDocValues = r.getSortedDocValues(fieldName);
                         if (sortedSetDocValues != null || sortedDocValues != null) {
-                            docValues.put(rc.docBase, Pair.of(sortedDocValues, sortedSetDocValues));
+                            docValues.put(rc.docBase, Pair.of(DocValuesUtil.cacher(sortedDocValues), DocValuesUtil.cacher(sortedSetDocValues)));
                         } else {
                             docValues.put(rc.docBase, null);
                         }
@@ -132,42 +134,38 @@ public class DocPropertyStoredField extends DocProperty {
     public String[] get(int docId) {
         if  (docValues != null) {
             // Find the fiid in the correct segment
-            Entry<Integer, Pair<SortedDocValues, SortedSetDocValues>> target = null;
-            for (Entry<Integer, Pair<SortedDocValues, SortedSetDocValues>> e : this.docValues.entrySet()) {
+            Entry<Integer, Pair<SortedDocValuesCacher, SortedSetDocValuesCacher>> target = null;
+            for (Entry<Integer, Pair<SortedDocValuesCacher, SortedSetDocValuesCacher>> e : this.docValues.entrySet()) {
                 if (e.getKey() > docId) { break; }
                 target = e;
             }
 
-            final List<String> ret = new ArrayList<>();
+            String[] ret = new String[0];
             if (target != null) {
                 final Integer targetDocBase = target.getKey();
-                final Pair<SortedDocValues, SortedSetDocValues> targetDocValues = target.getValue();
+                final Pair<SortedDocValuesCacher, SortedSetDocValuesCacher> targetDocValues = target.getValue();
                 if (targetDocValues != null) {
-                    SortedDocValues a = targetDocValues.getLeft();
-                    SortedSetDocValues b = targetDocValues.getRight();
+                    SortedDocValuesCacher a = targetDocValues.getLeft();
+                    SortedSetDocValuesCacher b = targetDocValues.getRight();
                     if (a != null) { // old index, only one value
                         synchronized (a) { // SortedDocValues is not thread-safe
-                            BytesRef val = a.get(docId - targetDocBase);
-                            ret.add(new String(val.bytes, val.offset, val.length, StandardCharsets.UTF_8));
+                            String value = a.get(docId - targetDocBase);
+                            ret = value == null ? new String[0] : new String[] { value };
                         }
                     } else { // newer index, (possibly) multiple values.
                         synchronized (b) { // SortedSetDocValues is not thread-safe
-                            b.setDocument(docId - targetDocBase);
-                            for (long ord = b.nextOrd(); ord != SortedSetDocValues.NO_MORE_ORDS; ord = b.nextOrd()) {
-                                BytesRef val = b.lookupOrd(ord);
-                                ret.add(new String(val.bytes, val.offset, val.length, StandardCharsets.UTF_8));
-                            }
+                            ret = b.get(docId - targetDocBase);
                         }
                     }
                 }
                 // If no docvalues for this segment - no values were indexed for this field (in this segment).
                 // So returning the empty array is good.
             }
-            return ret.toArray(new String[ret.size()]);
+            return ret;
         } else if (numericDocValues != null) {
             // Find the fiid in the correct segment
-            Entry<Integer, NumericDocValues> target = null;
-            for (Entry<Integer, NumericDocValues> e : this.numericDocValues.entrySet()) {
+            Entry<Integer, NumericDocValuesCacher> target = null;
+            for (Entry<Integer, NumericDocValuesCacher> e : this.numericDocValues.entrySet()) {
                 if (e.getKey() > docId) { break; }
                 target = e;
             }
@@ -175,7 +173,7 @@ public class DocPropertyStoredField extends DocProperty {
             final List<String> ret = new ArrayList<>();
             if (target != null) {
                 final Integer targetDocBase = target.getKey();
-                final NumericDocValues targetDocValues = target.getValue();
+                final NumericDocValuesCacher targetDocValues = target.getValue();
                 if (targetDocValues != null) {
                     synchronized (targetDocValues) {
                         ret.add(Long.toString(targetDocValues.get(docId - targetDocBase)));
@@ -184,7 +182,7 @@ public class DocPropertyStoredField extends DocProperty {
                 // If no docvalues for this segment - no values were indexed for this field (in this segment).
                 // So returning the empty array is good.
             }
-            return ret.toArray(new String[ret.size()]);
+            return ret.toArray(new String[0]);
         }
 
         // We don't have DocValues; just get the property from the document.

--- a/engine/src/main/java/nl/inl/blacklab/search/BlackLabIndexImpl.java
+++ b/engine/src/main/java/nl/inl/blacklab/search/BlackLabIndexImpl.java
@@ -567,7 +567,7 @@ public class BlackLabIndexImpl implements BlackLabIndexWriter {
             indexWriter = openIndexWriter(indexDir, createNewIndex, null);
             if (traceIndexOpening)
                 logger.debug("  Opening corresponding IndexReader...");
-            reader = DirectoryReader.open(indexWriter, false);
+            reader = DirectoryReader.open(indexWriter, false, false);
         } else {
             // Open Lucene index
             if (traceIndexOpening)
@@ -611,7 +611,7 @@ public class BlackLabIndexImpl implements BlackLabIndexWriter {
             indexWriter = openIndexWriter(indexDir, createNewIndex, analyzer);
             if (traceIndexOpening)
                 logger.debug("  IndexReader too...");
-            reader = DirectoryReader.open(indexWriter, false);
+            reader = DirectoryReader.open(indexWriter, false, false);
         }
 
         // Register ourselves in the mapping from IndexReader to BlackLabIndex,
@@ -861,7 +861,7 @@ public class BlackLabIndexImpl implements BlackLabIndexWriter {
         int deletedCount = 0;
         try {
             // Open a fresh reader to execute the query
-            try (IndexReader freshReader = DirectoryReader.open(indexWriter, false)) {
+            try (IndexReader freshReader = DirectoryReader.open(indexWriter, false, false)) {
                 // Execute the query, iterate over the docs and delete from FI and CS.
                 IndexSearcher s = new IndexSearcher(freshReader);
                 Weight w = s.createNormalizedWeight(q, false);

--- a/engine/src/main/java/nl/inl/blacklab/search/lucene/BLSpanWeight.java
+++ b/engine/src/main/java/nl/inl/blacklab/search/lucene/BLSpanWeight.java
@@ -18,7 +18,14 @@ public abstract class BLSpanWeight extends SpanWeight {
 
     public BLSpanWeight(SpanQuery query, IndexSearcher searcher, Map<Term, TermContext> termContexts)
             throws IOException {
-        super(query, searcher, termContexts);
+
+        // NOTE (chun.yu): About the 1.0f. I added this while upgrading the Lucene version for security.
+        //
+        // This constructor argument was added in Lucene 7.0 without much documentation. It appears to be
+        // a multiplier to be applied onto some scores. INL/Blacklab opted to have the BLSpanWeight constructor take a
+        // boost argument as well, allowing callers to specify. However, as of September 2024, the only concrete number used
+        // is 1.0f, so I'm hardcoding here to keep my upgrade simple and avoid modifying another ~20 files.
+        super(query, searcher, termContexts, 1.0f);
     }
 
     @Override

--- a/engine/src/main/java/nl/inl/blacklab/search/lucene/DocFieldLengthGetter.java
+++ b/engine/src/main/java/nl/inl/blacklab/search/lucene/DocFieldLengthGetter.java
@@ -76,7 +76,7 @@ class DocFieldLengthGetter implements Closeable {
                 if (cachedFieldLengths == null) {
                     // Use UninvertingReader to simulate DocValues (slower)
                     Map<String, UninvertingReader.Type> fields = new TreeMap<>();
-                    fields.put(lengthTokensFieldName, UninvertingReader.Type.INTEGER);
+                    fields.put(lengthTokensFieldName, UninvertingReader.Type.INTEGER_POINT);
                     @SuppressWarnings("resource")
                     UninvertingReader uninv = new UninvertingReader(reader, fields);
                     cachedFieldLengths = uninv.getNumericDocValues(lengthTokensFieldName);

--- a/engine/src/main/java/nl/inl/blacklab/search/lucene/DocFieldLengthGetter.java
+++ b/engine/src/main/java/nl/inl/blacklab/search/lucene/DocFieldLengthGetter.java
@@ -75,10 +75,8 @@ class DocFieldLengthGetter implements Closeable {
                 cachedFieldLengths = reader.getNumericDocValues(lengthTokensFieldName);
                 if (cachedFieldLengths == null) {
                     // Use UninvertingReader to simulate DocValues (slower)
-                    Map<String, UninvertingReader.Type> fields = new TreeMap<>();
-                    fields.put(lengthTokensFieldName, UninvertingReader.Type.INTEGER_POINT);
                     @SuppressWarnings("resource")
-                    UninvertingReader uninv = new UninvertingReader(reader, fields);
+                    LeafReader uninv = UninvertingReader.wrap(reader, (String s) -> UninvertingReader.Type.INTEGER_POINT);
                     cachedFieldLengths = uninv.getNumericDocValues(lengthTokensFieldName);
                 }
 

--- a/engine/src/main/java/nl/inl/blacklab/search/lucene/DocFieldLengthGetter.java
+++ b/engine/src/main/java/nl/inl/blacklab/search/lucene/DocFieldLengthGetter.java
@@ -11,7 +11,7 @@ import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.NumericDocValues;
 import org.apache.lucene.index.Terms;
 import org.apache.lucene.index.TermsEnum;
-import org.apache.lucene.uninverting.UninvertingReader;
+import org.apache.solr.uninverting.UninvertingReader;
 
 import nl.inl.blacklab.exceptions.BlackLabRuntimeException;
 import nl.inl.blacklab.index.Indexer;

--- a/engine/src/main/java/nl/inl/blacklab/search/lucene/DocIntFieldGetter.java
+++ b/engine/src/main/java/nl/inl/blacklab/search/lucene/DocIntFieldGetter.java
@@ -8,7 +8,7 @@ import java.util.TreeMap;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.NumericDocValues;
-import org.apache.lucene.uninverting.UninvertingReader;
+import org.apache.solr.uninverting.UninvertingReader;
 
 import nl.inl.blacklab.exceptions.BlackLabRuntimeException;
 

--- a/engine/src/main/java/nl/inl/blacklab/search/lucene/DocIntFieldGetter.java
+++ b/engine/src/main/java/nl/inl/blacklab/search/lucene/DocIntFieldGetter.java
@@ -42,7 +42,7 @@ public class DocIntFieldGetter implements Closeable {
             if (docValues == null) {
                 // Use UninvertingReader to simulate DocValues (slower)
                 Map<String, UninvertingReader.Type> fields = new TreeMap<>();
-                fields.put(intFieldName, UninvertingReader.Type.INTEGER);
+                fields.put(intFieldName, UninvertingReader.Type.INTEGER_POINT);
                 @SuppressWarnings("resource")
                 UninvertingReader uninv = new UninvertingReader(reader, fields);
                 docValues = uninv.getNumericDocValues(intFieldName);

--- a/engine/src/main/java/nl/inl/blacklab/search/lucene/DocIntFieldGetter.java
+++ b/engine/src/main/java/nl/inl/blacklab/search/lucene/DocIntFieldGetter.java
@@ -41,10 +41,8 @@ public class DocIntFieldGetter implements Closeable {
             docValues = reader.getNumericDocValues(intFieldName);
             if (docValues == null) {
                 // Use UninvertingReader to simulate DocValues (slower)
-                Map<String, UninvertingReader.Type> fields = new TreeMap<>();
-                fields.put(intFieldName, UninvertingReader.Type.INTEGER_POINT);
                 @SuppressWarnings("resource")
-                UninvertingReader uninv = new UninvertingReader(reader, fields);
+                LeafReader uninv = UninvertingReader.wrap(reader, (String s) -> UninvertingReader.Type.INTEGER_POINT);
                 docValues = uninv.getNumericDocValues(intFieldName);
             }
         } catch (IOException e) {

--- a/engine/src/main/java/nl/inl/util/DocValuesUtil.java
+++ b/engine/src/main/java/nl/inl/util/DocValuesUtil.java
@@ -1,0 +1,87 @@
+package nl.inl.util;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.index.NumericDocValues;
+import org.apache.lucene.index.SortedDocValues;
+import org.apache.lucene.index.SortedSetDocValues;
+import org.apache.lucene.search.DocIdSetIterator;
+
+public class DocValuesUtil {
+
+    public static SortedDocValuesCacher cacher(SortedDocValues dv) {
+        return dv == null ? null : new SortedDocValuesCacher(dv);
+    }
+
+    public static SortedSetDocValuesCacher cacher(SortedSetDocValues dv) {
+        return dv == null ? null : new SortedSetDocValuesCacher(dv);
+    }
+
+    public static NumericDocValuesCacher cacher(NumericDocValues dv) {
+        return dv == null ? null : new NumericDocValuesCacher(dv);
+    }
+
+    /**
+     * Get the appropriate DocValues instance for the given field.
+     *
+     * @param r index segment
+     * @param fieldName field to get DocValues for
+     * @param isNumeric whether the field is numeric
+     * @return DocValues instance, or null if field has no values in this segment
+     */
+    public static DocIdSetIterator docValuesIterator(LeafReader r, String fieldName, boolean isNumeric) throws
+            IOException {
+        DocIdSetIterator dv;
+        if (isNumeric) {
+            dv = r.getNumericDocValues(fieldName);
+        } else {
+            dv = r.getSortedSetDocValues(fieldName);
+            if (dv == null) {
+                dv = r.getSortedDocValues(fieldName);
+            }
+        }
+        return dv;
+    }
+
+    /**
+     * Get the current value from a DocValues instance and cast to string.
+     *
+     * NOTE: For multi-value fields, only returns the first value!
+     *
+     * @param dv DocValues instance positioned at a valid document
+     * @return value for this document
+     */
+    public static List<String> getCurrentValues(DocIdSetIterator dv) {
+        try {
+            List<String> key = null;
+            if (dv instanceof NumericDocValues)
+                key = List.of(Long.toString(((NumericDocValues) dv).longValue()));
+            else if (dv instanceof SortedSetDocValues) {
+                if (((SortedSetDocValues) dv).getValueCount() > 0) {
+                    // NOTE: we only count the first value stored (for backward compatibility)
+                    // TODO: pros/cons of changing this?
+                    SortedSetDocValues ssdv = (SortedSetDocValues) dv;
+                    while (true) {
+                        long ord = ssdv.nextOrd();
+                        if (ord == SortedSetDocValues.NO_MORE_ORDS)
+                            break;
+                        if (key == null)
+                            key = new ArrayList<>();
+                        key.add(ssdv.lookupOrd(ord).utf8ToString());
+                    }
+                }
+            } else if (dv instanceof SortedDocValues) {
+                key = List.of(((SortedDocValues) dv).binaryValue().utf8ToString());
+            } else {
+                throw new IllegalStateException("Unexpected DocValues type");
+            }
+            return key == null ? Collections.emptyList() : key;
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/engine/src/main/java/nl/inl/util/NumericDocValuesCacher.java
+++ b/engine/src/main/java/nl/inl/util/NumericDocValuesCacher.java
@@ -1,0 +1,69 @@
+package nl.inl.util;
+
+import java.io.IOException;
+
+import org.apache.lucene.index.NumericDocValues;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.eclipse.collections.api.map.primitive.MutableIntLongMap;
+import org.eclipse.collections.impl.map.mutable.primitive.IntLongHashMap;
+
+import net.jcip.annotations.NotThreadSafe;
+import nl.inl.blacklab.exceptions.BlackLabRuntimeException;
+
+/**
+ * Wrap a NumericDocValues to enable random access.
+ * <p>
+ * Not thread-safe.
+ */
+@NotThreadSafe
+public class NumericDocValuesCacher {
+
+    /**
+     * DocValues we're reading from
+     */
+    private final NumericDocValues source;
+
+    /**
+     * Have we called nextDoc on the source yet?
+     */
+    private boolean sourceNexted;
+
+    /**
+     * DocValues already read
+     */
+    private final MutableIntLongMap cache;
+
+    protected NumericDocValuesCacher(NumericDocValues source) {
+        this.source = source;
+        this.sourceNexted = false;
+        this.cache = new IntLongHashMap();
+    }
+
+    public synchronized long get(int docId) {
+        try {
+            // Have we been there before?
+            if (sourceNexted && source.docID() > docId) {
+                // We should have seen this value already.
+                // Produce it from the cache.
+                if (cache.containsKey(docId))
+                    return cache.get(docId);
+            } else {
+                // Advance to the requested id,
+                // storing all values we encounter.
+                while (source.docID() < docId) {
+                    int curDocId = source.nextDoc();
+                    if (curDocId == DocIdSetIterator.NO_MORE_DOCS)
+                        break;
+                    sourceNexted = true;
+                    cache.put(curDocId, source.longValue());
+                }
+                if (source.docID() == docId)
+                    return source.longValue();
+            }
+            return 0L; // default missing value
+        } catch (IOException e) {
+            throw BlackLabRuntimeException.wrap(e);
+        }
+    }
+
+}

--- a/engine/src/main/java/nl/inl/util/SortedDocValuesCacher.java
+++ b/engine/src/main/java/nl/inl/util/SortedDocValuesCacher.java
@@ -1,0 +1,74 @@
+package nl.inl.util;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.lucene.index.SortedDocValues;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.util.BytesRef;
+
+import net.jcip.annotations.NotThreadSafe;
+import nl.inl.blacklab.exceptions.BlackLabRuntimeException;
+
+/**
+ * Wrap a SortedDocValues to enable random access.
+ * <p>
+ * Not thread-safe.
+ */
+@NotThreadSafe
+public class SortedDocValuesCacher {
+
+    /**
+     * DocValues we're reading from
+     */
+    private final SortedDocValues source;
+
+    /**
+     * Have we called nextDoc on the source yet?
+     */
+    private boolean sourceNexted;
+
+    /**
+     * DocValues already read
+     */
+    private final Map<Integer, String> cache;
+
+    protected SortedDocValuesCacher(SortedDocValues source) {
+        this.source = source;
+        this.sourceNexted = false;
+        this.cache = new HashMap<>();
+    }
+
+    public synchronized String get(int docId) {
+        try {
+            // Have we been there before?
+            if (sourceNexted && source.docID() > docId) {
+                // We should have seen this value already.
+                // Produce it from the cache.
+                if (cache.containsKey(docId))
+                    return cache.get(docId);
+            } else {
+                // Advance to the requested id,
+                // storing all values we encounter.
+                while (source.docID() < docId) {
+                    int curDocId = source.nextDoc();
+                    if (curDocId == DocIdSetIterator.NO_MORE_DOCS)
+                        break;
+                    sourceNexted = true;
+                    BytesRef bytes = source.binaryValue();// equals to a.get(docId - targetDocBase)?
+                    String value = new String(bytes.bytes, bytes.offset, bytes.length, StandardCharsets.UTF_8);
+                    cache.put(curDocId, value);
+                }
+                if (source.docID() == docId) {
+                    return cache.get(docId);
+                }
+            }
+            return null; // default missing value
+        } catch (IOException e) {
+            throw BlackLabRuntimeException.wrap(e);
+        }
+    }
+
+}

--- a/engine/src/main/java/nl/inl/util/SortedSetDocValuesCacher.java
+++ b/engine/src/main/java/nl/inl/util/SortedSetDocValuesCacher.java
@@ -1,0 +1,83 @@
+package nl.inl.util;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.lucene.index.SortedSetDocValues;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.util.BytesRef;
+
+import net.jcip.annotations.NotThreadSafe;
+import nl.inl.blacklab.exceptions.BlackLabRuntimeException;
+
+/**
+ * Wrap a SortedSetDocValues to enable random access.
+ * <p>
+ * Not thread-safe.
+ */
+@NotThreadSafe
+public class SortedSetDocValuesCacher {
+
+    /**
+     * DocValues we're reading from
+     */
+    private final SortedSetDocValues source;
+
+    /**
+     * Have we called nextDoc on the source yet?
+     */
+    private boolean sourceNexted;
+
+    /**
+     * DocValues already read
+     */
+    private final Map<Integer, String[]> cache;
+
+    protected SortedSetDocValuesCacher(SortedSetDocValues source) {
+        this.source = source;
+        this.sourceNexted = false;
+        this.cache = new HashMap<>();
+    }
+
+    public synchronized String[] get(int docId) {
+        try {
+            // Have we been there before?
+            if (sourceNexted && source.docID() > docId) {
+                // We should have seen this value already.
+                // Produce it from the cache.
+                if (cache.containsKey(docId)) {
+                    return cache.get(docId);
+                }
+            } else {
+                // Advance to the requested id,
+                // storing all values we encounter.
+                while (source.docID() < docId) {
+                    int curDocId = source.nextDoc();
+                    if (curDocId == DocIdSetIterator.NO_MORE_DOCS) {
+                        break;
+                    }
+                    sourceNexted = true;
+
+                    final List<String> ret = new ArrayList<>();
+
+                    for (long ord = source.nextOrd(); ord != SortedSetDocValues.NO_MORE_ORDS; ord = source.nextOrd()) {
+                        BytesRef val = source.lookupOrd(ord);
+                        ret.add(new String(val.bytes, val.offset, val.length, StandardCharsets.UTF_8));
+                    }
+                    cache.put(curDocId, ret.toArray(new String[0]));
+                }
+                if (source.docID() == docId) {
+                    return cache.get(docId);
+                }
+            }
+            return new String[0]; // no values found; return empty array
+        } catch (IOException e) {
+            throw BlackLabRuntimeException.wrap(e);
+        }
+    }
+
+}

--- a/instrumentation/instrumentation-impl/pom.xml
+++ b/instrumentation/instrumentation-impl/pom.xml
@@ -36,7 +36,7 @@
     <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>ec2</artifactId>
-        <version>2.16.61</version>
+        <version>2.17.17</version>
     </dependency>
     <dependency>
         <groupId>org.apache.tomcat</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -34,10 +34,10 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <doclint>none</doclint>
-        <blacklab.luceneVersion>5.5.5</blacklab.luceneVersion>
+        <blacklab.luceneVersion>7.1.0</blacklab.luceneVersion>
         <blacklab.version>${project.version}</blacklab.version>
         <log4j.version>2.17.1</log4j.version>
-        <jackson.version>2.11.1</jackson.version>
+        <jackson.version>2.15.0</jackson.version>
         <eclipse.collections.version>7.1.0</eclipse.collections.version>
         <maven.compiler.source>9</maven.compiler.source>
         <maven.compiler.target>9</maven.compiler.target>

--- a/tools/src/main/java/nl/inl/blacklab/testutil/CountTokens.java
+++ b/tools/src/main/java/nl/inl/blacklab/testutil/CountTokens.java
@@ -41,7 +41,7 @@ public class CountTokens {
     }
 
     public static void main(String[] args) throws ErrorOpeningIndex {
-        LogUtil.setupBasicLoggingConfig(Level.DEBUG);
+        LogUtil.setupBasicLoggingConfig();
 
         if (args.length != 1) {
             System.out.println("Usage: CountTokens <indexDir>");

--- a/tools/src/main/java/nl/inl/blacklab/testutil/ExportCorpus.java
+++ b/tools/src/main/java/nl/inl/blacklab/testutil/ExportCorpus.java
@@ -20,7 +20,7 @@ import nl.inl.util.LogUtil;
 public class ExportCorpus implements AutoCloseable {
 
     public static void main(String[] args) throws ErrorOpeningIndex {
-        LogUtil.setupBasicLoggingConfig(Level.DEBUG);
+        LogUtil.setupBasicLoggingConfig();
 
         if (args.length != 2) {
             System.out.println("Usage: ExportCorpus <indexDir> <exportDir>");

--- a/tools/src/main/java/nl/inl/blacklab/testutil/ExportMetadata.java
+++ b/tools/src/main/java/nl/inl/blacklab/testutil/ExportMetadata.java
@@ -34,7 +34,7 @@ public class ExportMetadata implements AutoCloseable {
     }
 
     public static void main(String[] args) throws ErrorOpeningIndex, FileNotFoundException {
-        LogUtil.setupBasicLoggingConfig(Level.DEBUG);
+        LogUtil.setupBasicLoggingConfig();
 
         if (args.length != 2) {
             System.out.println("Usage: ExportMetadata <indexDir> <exportFile>");


### PR DESCRIPTION
## Lucene upgrade status

To be clear, I have yet to successfully build the project. This means despite the size of this PR, I have not been able to ascertain whether any of my changes will alter our inference performance and accuracy.

The list below summarizes the build issues I've seen while trying to build Blacklab with Lucene upgraded to 7.1.0. What is shown here only covers build errors that I have encountered in a partial build of 5 out of 15 packages of Blacklab (see build summary below). We can expect more errors further in the build.
```
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for BlackLab Corpus Search 2.3.0-SNAPSHOT:
[INFO] 
[INFO] BlackLab Corpus Search ............................. SUCCESS [  0.752 s]
[INFO] BlackLab Common .................................... SUCCESS [  0.233 s]
[INFO] BlackLab Utilities ................................. SUCCESS [  0.924 s]
[INFO] BlackLab Content Store ............................. SUCCESS [  0.054 s]
[INFO] BlackLab Engine .................................... FAILURE [  2.280 s]
[INFO] BlackLab Text Pattern .............................. SKIPPED
[INFO] BlackLab Query Parsers ............................. SKIPPED
[INFO] BlackLab Tools ..................................... SKIPPED
[INFO] BlackLab Mocks ..................................... SKIPPED
[INFO] BlackLab Core ...................................... SKIPPED
[INFO] BlackLab Instrumentation ........................... SKIPPED
[INFO] BlackLab Instrumentation Implementation ............ SKIPPED
[INFO] BlackLab Server .................................... SKIPPED
[INFO] BlackLab Convert and tag indexer ................... SKIPPED
[INFO] BlackLab legacy DocIndexers ........................ SKIPPED
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  4.531 s
[INFO] Finished at: 2024-09-09T11:59:36-07:00
[INFO] ------------------------------------------------------------------------
```

## Summary of issues

### To Do
- [NOT STARTED] `SpanQuery.createWeight()` signature changed 
    - **BL;UF:** About 20 Blacklab classes inherit from the abstract class `BLSpanQuery`, which in turn inherits from Lucene's abstract class `SpanQuery`, which has a `.createWeight()` method. Lucene 7.0 added a `boost` argument to `createWeight()`, requiring a sort of additional weight multiplier to be propagated (Lucene issue: https://github.com/apache/lucene/issues/8422).
    - INL/Blacklab implemented this additional argument to all 20 classes. I have not dug deep enough into how different each of them are to each other yet, but at minimum it will significantly increase the scope of this PR.
    - Error looks like this: `BLSpanTermQuery.java:[45,8] nl.inl.blacklab.search.lucene.BLSpanTermQuery is not abstract and does not override abstract method createWeight(org.apache.lucene.search.IndexSearcher,boolean,float) in org.apache.lucene.search.spans.SpanQuery`

- [IN PROGRESS] `DocValues` breaking changes (`NumericDocValues`, `SortedDocValues`, `SortedSetDocValues` in Blacklab)
    - **BL;UF:** Lucene has a data structure called `DocValues` that provides per-document value storage. Prior to 7.0, Lucene allowed easy access to values by document ID, with key-value store ergonomics. Lucene 7.0 introduced a major breaking change that mandated all `DocValues` be accessed in an iterator pattern instead of the aforementioned random access pattern, citing improved performance.
    - Links:
      - https://blog.mikemccandless.com/2017/03/apache-lucene-70-is-coming-soon.html
      - https://stackoverflow.com/questions/48474506/how-to-get-docvalue-by-document-id-in-lucene-7
    - All calls to `{*Type}DocValues.get(docId)` on Blacklab are no longer supported. Need to change all instances to an iterator pattern
    - INL wrote wrappers around some of the classes, called `NumericDocValuesCacher`, `SortedDocValuesCacher`, and `SortedSetDocValuesCacher` to reenable the random access pattern pre-Lucene 7. The iterator pattern may have broken their perf, and would probably break us too. For my part, I copied their cachers over and mainly tried to take cues from their changes and incorporate them into our classes.
      - https://github.com/INL/BlackLab/pull/264/
    - Places to replace `get()` at:
        - [DONE] `DocPropertyStoredField.java` - Switched to cachers
        - [DONE] `DocFieldLengthGetter.java` - Switched to iterator pattern
        - [DONE] `DocResults.java` - Switched to iterator pattern
        - [DONE] `FiidLookup.java` - Switched to iterator with a cache
        - [DONE] `DocPropertyAnnotatedFieldLength.java` - Switched to cachers
        - [NOT STARTED] `DocIntFieldGetter.java` - To accommodate the new `DocValues` architecture for this class, INL made changes that impacted its thread safety (https://github.com/INL/BlackLab/pull/264/files#diff-ed79e51653d511f0d432e54fa075686ffc868dbdb540c0cf029e965670f0f727). I don't feel I can simply copy what INL did in this one file without understanding what it does, and it's not clear yet how many downstream effects and changes will need to be accounted for in the codebase.

### Done
- [DONE] Uninverting library removed from Lucene
    - **BL;UF:** The uninverting library was moved to Solr at 7.0, necessitating either pulling Solr into Blacklab or significantly refactoring the code to not use the uninverting package.
    - Removal: https://issues.apache.org/jira/browse/LUCENE-7283, https://github.com/apache/lucene/issues/8338
    - Error looks like this: `package org.apache.lucene.uninverting does not exist`

- [DONE] `IntField` removed from Lucene
    - **BL;UF:** `IntField` was removed from Lucene at 6.4.0. It's reintroduced at 9.5.0.
    - Migration guide: https://lucene.apache.org/core/6_4_0/MIGRATE.html
      - tl;dr: replace with `IntPoint` and `StoredField`: https://stackoverflow.com/questions/42659616/lucene-6-adding-intfields
    - Error looks like this: `org.apache.lucene.document.IntField: cannot find symbol`

- [DONE] `SpanWeight` constructor signature changed
    - **BL;UF:** There's a new float called `boost` in SpanWeight constructor
    - Error looks like this: `BLSpanWeight.java:[21,9] constructor SpanWeight in class org.apache.lucene.search.spans.SpanWeight cannot be applied to given types`

- [DONE] `UninvertingReader` constructor removed
    - **BL;UF:** The public constructor was removed. There's a static method called `wrap` that takes in a `LeafReader` and a mapping function from string to type
    - https://javadoc.io/doc/org.apache.solr/solr-core/latest/org/apache/solr/uninverting/UninvertingReader.html
    - Mapping func: `(String s) -> UninvertingReader.Type.INTEGER_POINT`
    - Error looks like this: `DocFieldLengthGetter.java:[81,47] constructor UninvertingReader in class org.apache.solr.uninverting.UninvertingReader cannot be applied to given types;`

- [DONE] `UninvertingReader` constants removed
    - `INTEGER_POINT` for `IntPoint` or `LEGACY_INTEGER` for old `IntField`, I'm guessing
    - Since I moved to IntPoint/StorageField across the board, `INTEGER_POINT` seems reasonable
    - Error looks like this: Cannot find symbol `UninvertingReader.Type.INTEGER`

- [DONE] `DirectoryReader.open()` signature changed
    - Now requires input on whether to write deletes. I copied what INL did.