### PR TITLE
Upgrade AWS SDK and Jackson library

### DIFF
--- a/instrumentation/instrumentation-impl/pom.xml
+++ b/instrumentation/instrumentation-impl/pom.xml
@@ -36,7 +36,7 @@
     <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>ec2</artifactId>
-        <version>2.16.61</version>
+        <version>2.17.17</version>
     </dependency>
     <dependency>
         <groupId>org.apache.tomcat</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
         <blacklab.luceneVersion>5.5.5</blacklab.luceneVersion>
         <blacklab.version>${project.version}</blacklab.version>
         <log4j.version>2.17.1</log4j.version>
-        <jackson.version>2.11.1</jackson.version>
+        <jackson.version>2.15.0</jackson.version>
         <eclipse.collections.version>7.1.0</eclipse.collections.version>
         <maven.compiler.source>9</maven.compiler.source>
         <maven.compiler.target>9</maven.compiler.target>

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
         <blacklab.luceneVersion>5.5.5</blacklab.luceneVersion>
         <blacklab.version>${project.version}</blacklab.version>
         <log4j.version>2.17.1</log4j.version>
-        <jackson.version>2.15.0</jackson.version>
+        <jackson.version>2.17.2</jackson.version>
         <eclipse.collections.version>7.1.0</eclipse.collections.version>
         <maven.compiler.source>9</maven.compiler.source>
         <maven.compiler.target>9</maven.compiler.target>

--- a/test/run.sh
+++ b/test/run.sh
@@ -6,13 +6,13 @@ export DOCKER_BUILDKIT=1
 
 # Build and run BlackLab Server
 # (--force-recreate to avoid error 'network not found')
-docker-compose up --force-recreate -d --build testserver
+docker compose up --force-recreate -d --build testserver
 
 # Build and run the test suite
-docker-compose build test
-docker-compose run --rm test
+docker compose build test
+docker compose run --rm test
 
 # Clean up
 # (stop then down to avoid warning about network in use)
-docker-compose stop testserver
-docker-compose down -v
+docker compose stop testserver
+docker compose down -v


### PR DESCRIPTION
This PR implements a couple security upgrades for our package dependencies.
The affected packages aren't directly referenced by our project. I determined the actual dependencies to update by tracking down where the targeted packages are in `mvn dependency:tree`.

### Packages in question
- snakeyaml 1.26 -> 2.0
  - Covered by pushing `jackson-dataformat-yaml` up from 2.11.1 to 2.17.2
  - Modules impacted
    - blacklab-util
    - blacklab-engine
    - blacklab-text-pattern
- jackson-databind 2.11.1 -> 2.12.7
  - Covered by pushing `jackson-dataformat-yaml` up from 2.11.1 to 2.17.2
  - Modules impacted
    - blacklab-util
    - blacklab-engine
    - blacklab-instrumentation
- netty 4.1.63 -> 4.1.108
    - Covered by upgrading `software.amazon.awssdk:ec2:jar` from 2.16.61 to 2.27.17 (but still has vulns despite being the latest)