### PR TITLE
Silence most non-essential log messages from Blacklab

### DIFF
--- a/server/src/main/java/nl/inl/blacklab/server/search/ResultsCache.java
+++ b/server/src/main/java/nl/inl/blacklab/server/search/ResultsCache.java
@@ -5,27 +5,24 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import io.micrometer.core.instrument.Counter;
-import nl.inl.blacklab.exceptions.BlackLabRuntimeException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.ThreadContext;
-import org.checkerframework.checker.nullness.qual.Nullable;
 
 import com.github.benmanes.caffeine.cache.AsyncLoadingCache;
 import com.github.benmanes.caffeine.cache.CacheLoader;
 import com.github.benmanes.caffeine.cache.Caffeine;
 
+import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.binder.cache.CaffeineCacheMetrics;
+import nl.inl.blacklab.exceptions.BlackLabRuntimeException;
 import nl.inl.blacklab.search.BlackLabIndex;
 import nl.inl.blacklab.search.results.SearchResult;
 import nl.inl.blacklab.searches.Search;
@@ -166,7 +163,7 @@ public class ResultsCache implements SearchCache {
                     } else {
                          searchResult = job.get();
                     }
-                    logger.warn("Internal search time is: {}", searchResult.timeUserWaitedMs());
+                    logger.debug("Internal search time is: {}", searchResult.timeUserWaitedMs());
                     return searchResult.getResults();
                 } catch (TimeoutException ex) {
                     logger.warn("Search took to long: {}", searchWrapper.search);

--- a/server/src/main/resources/log4j2.xml
+++ b/server/src/main/resources/log4j2.xml
@@ -7,7 +7,7 @@
 		</Console>
 	</Appenders>
 	<Loggers>
-		<Root level="debug">
+		<Root level="WARN">
 			<AppenderRef ref="Console" />
 		</Root>
 		<Logger name="io.netty" level="ERROR"/>


### PR DESCRIPTION
Blacklab currently outputs log messages that are not super useful to us and can overwhelm essential investigations. This PR sets the Blacklab log level to WARN and downgrades one major source of logs down from WARN to DEBUG.